### PR TITLE
feat(#40): 태그 공용컴포넌트 구현

### DIFF
--- a/src/app/sample/_components/Jin.tsx
+++ b/src/app/sample/_components/Jin.tsx
@@ -1,11 +1,28 @@
+'use client';
+
+import { Tags } from '@/components/Tags';
+import { useState } from 'react';
+
 export default function Jin() {
+  // 테스트용 데이터 (태그 배열)
+  const [tags, setTags] = useState([
+    { id: 1, name: 'React' },
+    { id: 2, name: 'JavaScript' },
+    { id: 3, name: 'TypeScript' },
+  ]);
+
+  // 태그 삭제 함수 (부모 컴포넌트에서 처리)
+  const onRemoveTag = (tag: { id: number; name: string }) => {
+    setTags((prevTags) => prevTags.filter((t) => t.id !== tag.id));
+  };
+
   return (
-    <>
-      <div className="border border-gray-200 bg-gray-50 p-5">
-        <h3 className="mb-5 text-xl font-bold">1. 컴포넌트명</h3>
-        <p className="mb-5 leading-7">설명</p>
-        <div className="bg-white p-5">컴포넌트 구현</div>
+    <div className="border border-gray-200 bg-gray-50 p-5">
+      <h3 className="mb-5 text-xl font-bold">1. 태그 공용컴포넌트</h3>
+      <p className="mb-5 leading-7">설명</p>
+      <div className="bg-white p-5">
+        <Tags tags={tags} onRemoveTag={onRemoveTag} />
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -1,0 +1,30 @@
+import { EpigramTag } from '../types/Epigram';
+
+interface TagsProps {
+  tags: EpigramTag[];
+  onRemoveTag: (tag: EpigramTag) => void;
+}
+
+export function Tags({ tags, onRemoveTag }: TagsProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag) => (
+        <div
+          key={tag.id}
+          className="mobile:px-[12px] mobile:py-[8px] mobile:rounded-[20px] mobile:text-[16px] mobile:leading-[26px] tablet:px-[12px] tablet:py-[8px] tablet:rounded-[20px] tablet:text-[20px] tablet:leading-[32px] pc:px-[14px] pc:py-[12px] pc:rounded-[22px] pc:text-[24px] pc:leading-[32px] flex items-center gap-2 rounded-[18px] bg-[var(--color-bg-100)] text-[#5E5E5E]"
+        >
+          <span className="mobile:text-[16px] mobile:leading-[26px] tablet:text-[20px] tablet:leading-[32px] pc:text-[24px] pc:leading-[32px] text-[16px] leading-[26px] font-normal text-[#5E5E5E]">
+            {tag.name}
+          </span>
+          <button
+            type="button"
+            onClick={() => onRemoveTag(tag)}
+            className="text-[var(--color-blue-500)] hover:text-[var(--color-blue-9500)]"
+          >
+            x
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣ 이슈

- close #40 

## 📝 작업 내용
태그 공용컴포넌트 구현
해당 컴포넌트에서 타입 지정
컴포넌트에 x버튼 생성. x버튼 클릭시 태그 삭제 구현


반응형 구현.

## 📸 결과물


https://github.com/user-attachments/assets/958973a9-dd0d-441d-ab8b-f24659507dcf



## 👩‍💻 공유 포인트 및 논의 사항
삭제 로직은 가져가서 사용하는 부모컴포넌트에서  onRemoveTag 함수를 정의해야함.
![4](https://github.com/user-attachments/assets/4f778639-6127-422c-b774-fcdbad7d54c0)
(이런식으로..)

그리고... 피그마에서는 원래 x버튼이 없었지만, 만들어놓은 상태.. 입력창안에 태그가 나오는식이면 키보드 백스페이스 방식으로 지우는걸 구현할 수 있기는한데, 피그마상 입력상자 아래쪽에 태그가 나오다보니 삭제 기능 구현이 있는게 좋을듯하여 만들었습니다.
