### PR TITLE
Feat(#39): 공용컴포넌트 버튼

### DIFF
--- a/src/app/sample/_components/Gyeong.tsx
+++ b/src/app/sample/_components/Gyeong.tsx
@@ -1,3 +1,5 @@
+import ClientButton from '@/components/Button/ClientButton';
+import ServerButton from '@/components/Button/ServerButton';
 import TodayEmotion from '@/components/TodayEmotion';
 
 export default function Gyeong() {
@@ -12,9 +14,42 @@ export default function Gyeong() {
           <br /> 클릭시 서버에 api요청도 보내게됩니다. 이때 header에 acessToken이 필요합니다!
           <br /> 로그인 기능이 아직 구현 전이라서 테스트를 원하실 경우 직접 api에 토큰을 넣어주세요.
         </p>
-        <div className="bg-white p-5">
+        <div className="mb-5 bg-white p-5">
           <TodayEmotion emotionType="main" />
           <TodayEmotion emotionType="mypage" />
+        </div>
+        <h3 className="mb-5 text-xl font-bold">2. 버튼</h3>
+        <p className="mb-5 leading-7">
+          서버 컴포넌트용 ServerButton과 클라이언트 컴포넌트용 ClientButton입니다.
+          <br />두 컴포넌트의 디자인은 동일하지만 감싸져있는 태그가 다릅니다. <br />
+          서버: Link, span
+          <br />
+          클라이언트: Button
+          <br />
+          서버 컴포넌트나 페이지 내부에서 다른 주소로 이동만 시켜주는 버튼의 경우 서버버튼을 활용하시면 됩니다!
+          <br />
+          버튼에 onClick속성이 필요하시거나 form 제출의 경우 클라이언트 버튼을 활용해주세요!
+          <br />
+        </p>
+        <div className="bg-white">
+          <ServerButton isValid href={'/'}>
+            서버버튼
+          </ServerButton>
+          <ServerButton isValid={false} href={'/'}>
+            서버버튼
+          </ServerButton>
+          <ServerButton isValid href={'/'} isRounded>
+            서버버튼
+          </ServerButton>
+          <ServerButton isValid={false} href={'/'} isRounded>
+            서버버튼
+          </ServerButton>
+          <ClientButton isValid className="w-full">
+            클라이언트
+          </ClientButton>
+          <ClientButton isValid={false} className="w-full">
+            클라이언트
+          </ClientButton>
         </div>
       </div>
     </>

--- a/src/components/Button/ClientButton.tsx
+++ b/src/components/Button/ClientButton.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+interface ClientButtonProps {
+  isValid: boolean;
+  children: ReactNode;
+  type?: 'submit' | 'button';
+  onClick?: () => void;
+  className?: string;
+  isRounded?: boolean;
+}
+
+export default function ClientButton({
+  isValid,
+  children,
+  type = 'button',
+  onClick,
+  className = '',
+  isRounded = false,
+}: ClientButtonProps) {
+  return (
+    <button
+      className={`text-pre-lg pc:text-pre-xl pc:py-[16px] max-w-[640px] transition-colors duration-300 ${isRounded ? 'rounded-[100px]' : 'rounded-[12px]'} px-[16px] py-[9px] font-semibold text-blue-100 ${isValid ? `bg-black-500 hover:bg-black-400 cursor-pointer` : `bg-blue-300`} ${className}`}
+      type={type}
+      disabled={!isValid}
+      onClick={() => onClick?.()}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/Button/ServerButton.tsx
+++ b/src/components/Button/ServerButton.tsx
@@ -27,7 +27,7 @@ export default function ServerButton({
         </Link>
       ) : (
         <span
-          className={`text-pre-lg pc:text-pre-xl inline-block max-w-[640px] justify-center ${isRounded ? 'rounded-[100px]' : 'rounded-[12px]'} bg-blue-300 px-[16px] py-[9px] font-semibold text-blue-100 ${className}`}
+          className={`text-pre-lg pc:text-pre-xl inline-block max-w-[640px] ${isRounded ? 'rounded-[100px]' : 'rounded-[12px]'} bg-blue-300 px-[28px] py-[11px] font-semibold text-blue-100 ${className}`}
         >
           {children}
         </span>

--- a/src/components/Button/ServerButton.tsx
+++ b/src/components/Button/ServerButton.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+interface ServerButtonProps {
+  isValid: boolean;
+  href: string;
+  className?: string;
+  isRounded?: boolean;
+  children: ReactNode;
+}
+
+export default function ServerButton({
+  isValid,
+  href,
+  className = '',
+  isRounded = false,
+  children,
+}: ServerButtonProps) {
+  return (
+    <>
+      {isValid ? (
+        <Link
+          className={`text-pre-lg pc:text-pre-xl bg-black-500 hover:bg-black-400 inline-block max-w-[640px] cursor-pointer transition-colors duration-300 ${isRounded ? 'rounded-[100px]' : 'rounded-[12px]'} px-[28px] py-[11px] font-semibold text-blue-100 ${className}`}
+          href={href}
+        >
+          {children}
+        </Link>
+      ) : (
+        <span
+          className={`text-pre-lg pc:text-pre-xl inline-block max-w-[640px] justify-center ${isRounded ? 'rounded-[100px]' : 'rounded-[12px]'} bg-blue-300 px-[16px] py-[9px] font-semibold text-blue-100 ${className}`}
+        >
+          {children}
+        </span>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## #️⃣ 이슈

- close #39 

## 📝 작업 내용

프로젝트 내부에서 공용으로 사용할 수 있는 버튼 컴포넌트를 구현했습니다.
ServerButton.tsx 서버 컴포넌트
ClientButton.tsx 클라이언트 컴포넌트로 나뉘어져 있으니
필요한 기능에 따라 사용하시면 됩니다.

**- ServerButton** (Link/span)
페이지 내부에서 다른 주소로 이동만 시켜주는 버튼

**필수 prop**
isValid: 버튼의 disable 유무를 선택합니다.
href: Link를 클릭시 이동할 위치를 string으로 받습니다. ex) '/'
children: 버튼 내부에 들어갈 내용 ex)로그인, 회원가입, 시작하기....

**선택 prop**
className: 버튼 디자인을 커스텀할 수 있습니다. px와 py등등 각 페이지에서 다르게 쓰이는 디자인을 적용할때 활용해주세요!
isRounded: 이 속성을 주면 동그란 버튼이 됩니다. 기본적으로 false입니다.

**- ClientButton** (button)
onClick속성이 필요하시거나 form 제출

**필수 prop**
isValid: 버튼의 disable 유무를 선택합니다.
children: 버튼 내부에 들어갈 내용

**선택 prop**
type: button태그 type을 submit과 button중 선택할 수 있습니다. 기본 button
onClick: 버튼 클릭시 실행할 함수를 전달할 수 있습니다.
className: 버튼 디자인을 커스텀
isRounded: 동그란 버튼. 기본 false

## 📸 결과물

![image](https://github.com/user-attachments/assets/da47dc4e-076e-4b0b-8212-19affb9bd318)


## 👩‍💻 공유 포인트 및 논의 사항
