### PR TITLE
fix:회원가입페이지 nextauth와의 연결

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -21,7 +21,6 @@ export default function LoginPage() {
   const [error, setError] = useState<string>('');
   const router = useRouter();
 
-  console.log('세션', session);
   const {
     register,
     handleSubmit,
@@ -38,9 +37,7 @@ export default function LoginPage() {
       email: data.email,
       password: data.password,
       redirect: false, // 자동 리다이렉트 방지
-    });
-
-    console.log('signIn 응답:', res); // 응답 로그 확인
+    }); // 응답 로그 확인
 
     if (res?.error) {
       setError(res.error); // NextAuth에서 받은 에러 메시지를 그대로 사용

--- a/src/lib/next-auth/auth.ts
+++ b/src/lib/next-auth/auth.ts
@@ -3,7 +3,6 @@ import CredentialsProvider from 'next-auth/providers/credentials';
 import { signinSchema, signupSchema } from '@/lib/validation/auth';
 
 export const auth = NextAuth({
-  debug: true, // 디버깅 활성화
   session: {
     strategy: 'jwt', //jwt 기반 인증
   },
@@ -25,62 +24,37 @@ export const auth = NextAuth({
         const loginParse = signinSchema.safeParse(credentials); //zod스키마를 활용한 유효성 검사 적용.
         if (loginParse.success) {
           //유효성 검사 성공 시
-          try {
-            const loginData = {
-              email: loginParse.data.email,
-              password: loginParse.data.password,
-            };
-            //json형식으로
-            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signIn`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json', // JSON 타입 명시
-              },
-              body: JSON.stringify(loginData),
-            });
-            const text = await res.text();
-            console.log('API 응답:', text); // api를 불러오는 것 제대로 불러옴.
-
-            if (res.status >= 400 && res.status < 500) {
-              // 서버에서 400에러로 응답시..
-              throw new Error('로그인하는데 실패하였습니다.');
-            }
-
-            if (!res.ok) {
-              // API 응답이 실패했을 경우, 메시지를 직접 사용
-              let errorMessage = '로그인에 실패하였습니다.';
-              try {
-                const errorResponse = JSON.parse(text);
-                if (errorResponse.message) {
-                  errorMessage = errorResponse.message;
-                }
-              } catch (parseError) {
-                console.error('API 응답 파싱 오류:', parseError);
-              }
-              throw new Error(errorMessage); // 에러 메시지를 직접 던짐
-            }
-
-            const user = JSON.parse(text);
-            console.log('서버 응답:', user);
-
-            if (!user || !user.user || !user.accessToken) {
-              console.error('잘못된 응답 구조:', user);
-              throw new Error('서버에서 잘못된 데이터를 반환하였습니다.');
-            }
-
-            return {
-              //user데이터를 받아오는 것이라서 user.user로 해야한다.
-              id: user.user.id,
-              email: user.user.email,
-              accessToken: user.user.accessToken,
-              refreshToken: user.user.refreshToken,
-            };
-          } catch (error) {
-            if (error instanceof Error) {
-              console.error('로그인 오류:', error);
-              throw new Error(error.message || '알 수 없는 오류가 발생하였습니다.');
-            }
+          const loginData = {
+            email: loginParse.data.email,
+            password: loginParse.data.password,
+          };
+          //json형식으로
+          const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signIn`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json', // JSON 타입 명시
+            },
+            body: JSON.stringify(loginData),
+          });
+          //비밀번호나 이메일이 틀릴시 401응답을 보내는게 정상
+          if (res.status >= 400 && res.status < 500) {
+            // 서버에서 400에러로 응답시..
+            throw new Error('이메일 또는 비밀번호가 다릅니다.');
           }
+
+          if (!res?.ok || res === null) {
+            throw new Error('서버 오류가 발생하였습니다. 잠시 후 다시 시도해주세요.');
+          }
+
+          const user = await res.json();
+
+          return {
+            //user데이터를 받아오는 것이라서 user.user로 해야한다.
+            id: user.user.id,
+            email: user.user.email,
+            accessToken: user.user.accessToken,
+            refreshToken: user.user.refreshToken,
+          };
         }
         // 회원가입부분
         const signUpParse = signupSchema.safeParse(credentials); //zod스키마를 통한 유효성 검사
@@ -122,21 +96,17 @@ export const auth = NextAuth({
   callbacks: {
     async jwt({ token, user }) {
       if (user) {
-        console.log('JWT 콜백에서 받은 user:', user); //받은 유저 객체확인
         token.accessToken = user.accessToken;
         token.refreshToken = user.refreshToken;
         token.id = Number(user.id);
         token.email = user.email;
       }
-      console.log('JWT 콜백에서 반환된 token:', token); // 반환된 토큰 확인.
       return token;
     },
     async session({ session, token }) {
-      console.log('Session 콜백에서 받은 token:', token); // 받은 토큰 확인
       session.user.id = token.id;
       session.user.email = token.email ?? '';
       session.accessToken = token.accessToken;
-      console.log('Session 콜백에서 설정된 session:', session); // 설정된 session 객체 확인
       return session;
     },
   },

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -17,7 +17,7 @@ export interface Auth {
 }
 
 //토큰 갱신 타입
-export interface RefreshToken {
+export interface accessToken {
   accessToken: string;
 }
 


### PR DESCRIPTION
## #️⃣ 이슈

- close #46 

## 📝 작업 내용
-회원가입페이지도 nextauth와 연결시킴.
## 📸 결과물
![스크린샷 2025-03-20 오전 1 45 53](https://github.com/user-attachments/assets/49856b57-e8ae-46a6-a0ba-f45ee4092848)

## 👩‍💻 공유 포인트 및 논의 사항
현재 확인해보니 로그인페이지와 회원가입 페이지의 유효성 검사를 스키마가 아닌 개별적으로 하는 것 같습니다.. 그래서 그거에 대한 수정이 필요하고 논의 사항으로는 현재 api에서 에러메세지를 전달해주는데 로그인할 때는 이메일이 다르면 '존재하지 않는 이메일입니다.' 그리고 비밀번호가 다를 시 '비밀번호가 일치하지 않습니다.' 라고 메세지를 전달해줍니다. 이것에 대한 내용을 일반 사용자들에게 보여지게 할지 아니면 지금 현재 독자적으로 '이메일또는 비밀번호가 다릅니다.'라고 메세지내용을 나타나게 했는데 이것으로 할지 의논이 필요합니다. 일단 sessionToken을 앞으로 작업해가야하는데 써야할거 같아서 먼저 올리고 멘토님이 말하신 내용과 수정할 부분들은 앞으로 조금씩 수정해나가겠습니다.