### PR TITLE
Feat(#58): 에피그램 만들기수정하기

### DIFF
--- a/public/assets/icons/x_gray.svg
+++ b/public/assets/icons/x_gray.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 7L7 17" stroke="#373737" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M7 7L17 17" stroke="#373737" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/app/addepigram/layout.tsx
+++ b/src/app/addepigram/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  return <div className="p-[24px]">{children}</div>;
+}

--- a/src/app/addepigram/layout.tsx
+++ b/src/app/addepigram/layout.tsx
@@ -5,5 +5,5 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  return <div className="p-[24px]">{children}</div>;
+  return <div className="tablet:py-[32px] pc:py-[56px] flex w-full justify-center p-[24px]">{children}</div>;
 }

--- a/src/app/addepigram/page.tsx
+++ b/src/app/addepigram/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 
+import { PostEpigram } from '@/lib/Epigram';
+import { ChangeEvent, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
-interface AddEpigram {
+export interface AddEpigram {
   tags: string[];
   referenceUrl: string;
   referenceTitle: string;
   author: string;
   content: string;
+  authorSelected: string;
 }
 
 export default function Page() {
@@ -15,6 +18,8 @@ export default function Page() {
     register,
     handleSubmit,
     formState: { isValid },
+    watch,
+    setValue,
   } = useForm<AddEpigram>({
     mode: 'onChange',
     defaultValues: {
@@ -23,12 +28,36 @@ export default function Page() {
       referenceTitle: '',
       author: '',
       content: '',
+      authorSelected: '직접 입력',
     },
   });
 
-  const SubmitForm = () => {
+  const selectedOption = watch('authorSelected');
+  const author = watch('author');
+  const content = watch('content');
+  const maxLength = 500;
+
+  const handleInputChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const value = event.target.value;
+    if (value.length <= maxLength) {
+      setValue('content', value);
+    }
+  };
+
+  const SubmitForm = async () => {
+    const allValues = watch();
+    const response = await PostEpigram(allValues);
+    if (!response) return;
     console.log('폼 제출');
   };
+
+  useEffect(() => {
+    if (selectedOption === '알 수 없음' || selectedOption === '본인') {
+      setValue('author', selectedOption);
+    } else {
+      setValue('author', '');
+    }
+  }, [selectedOption, setValue]);
 
   return (
     <div className="flex flex-col gap-[24px]">
@@ -49,6 +78,8 @@ export default function Page() {
               className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[132px] resize-none rounded-[12px] border border-blue-300 px-[16px] py-[10px] placeholder:text-blue-400 focus:outline-blue-600"
               placeholder="500자 이내로 입력해주세요."
               {...register('content', { required: '내용을 입력해주세요' })}
+              value={content}
+              onChange={handleInputChange}
             />
           </div>
           <div className="flex flex-col gap-[8px]">
@@ -60,22 +91,28 @@ export default function Page() {
                 <label htmlFor="직접 입력" className="relative flex cursor-pointer items-center gap-[8px]">
                   <input
                     id="직접 입력"
-                    name="author"
                     type="radio"
                     value="직접 입력"
                     className="peer hidden"
+                    {...register('authorSelected')}
                     defaultChecked
                   />
                   <div className="h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
                   <span className="text-pre-lg text-black-600 font-medium">직접 입력</span>
                 </label>
                 <label htmlFor="알 수 없음" className="relative flex cursor-pointer items-center gap-[8px]">
-                  <input id="알 수 없음" name="author" type="radio" value="알 수 없음" className="peer hidden" />
+                  <input
+                    id="알 수 없음"
+                    type="radio"
+                    value="알 수 없음"
+                    className="peer hidden"
+                    {...register('authorSelected')}
+                  />
                   <div className="h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
                   <span className="text-pre-lg text-black-600 font-medium">알 수 없음</span>
                 </label>
                 <label htmlFor="본인" className="relative flex cursor-pointer items-center gap-[8px]">
-                  <input id="본인" name="author" type="radio" value="본인" className="peer hidden" />
+                  <input id="본인" type="radio" value="본인" className="peer hidden" {...register('authorSelected')} />
                   <div className="h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
                   <span className="text-pre-lg text-black-600 font-medium">본인</span>
                 </label>
@@ -84,6 +121,8 @@ export default function Page() {
                 id="author"
                 className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
                 placeholder="저자 이름 입력"
+                value={author}
+                disabled={selectedOption !== '직접 입력'}
                 {...register('author', { required: '저자를 입력해주세요' })}
               />
             </div>

--- a/src/app/addepigram/page.tsx
+++ b/src/app/addepigram/page.tsx
@@ -15,6 +15,17 @@ export interface AddEpigram {
   authorSelected: string;
 }
 
+// const initialValue = {
+//   tags: [
+//     { id: 1, name: '꿈을이루고싶을때' },
+//     { id: 2, name: '나아가야할때' },
+//   ],
+//   referenceUrl: 'https://www.naver.com',
+//   referenceTitle: '나무위키',
+//   author: '앙드레 말로',
+//   content: '오랫동안 꿈을 그리는 사람은 마침내 그 꿈을 닮아 간다.',
+// };
+
 export default function Page() {
   const {
     register,
@@ -50,7 +61,7 @@ export default function Page() {
     const allValues = watch();
     const response = await PostEpigram(allValues);
     if (!response) return;
-    console.log('폼 제출');
+    alert('폼 제출 완료');
   };
 
   useEffect(() => {
@@ -62,36 +73,44 @@ export default function Page() {
   }, [selectedOption, setValue]);
 
   return (
-    <div className="flex flex-col gap-[24px]">
-      <h1 className="text-pre-lg text-black-700 font-semibold">에피그램 만들기</h1>
-      <form onSubmit={handleSubmit(SubmitForm)} className="flex flex-col gap-[24px]">
-        <div className="flex flex-col gap-[40px]">
-          <div className="flex flex-col gap-[8px]">
+    <div className="tablet:max-w-[384px] pc:max-w-[640px] tablet:gap-[32px] pc:gap-[40px] flex w-full flex-col gap-[24px]">
+      <h1 className="text-pre-lg text-black-700 tablet:text-pre-xl pc:text-pre-2xl font-semibold">에피그램 만들기</h1>
+      <form onSubmit={handleSubmit(SubmitForm)} className="pc:gap-[40px] flex flex-col gap-[24px]">
+        <div className="pc:gap-[54px] flex flex-col gap-[40px]">
+          <div className="pc:gap-[24px] flex flex-col gap-[8px]">
             <div className="flex justify-between">
               <div className="flex gap-[4px]">
-                <label htmlFor="content" className="text-pre-md text-black-600 font-semibold">
+                <label
+                  htmlFor="content"
+                  className="text-pre-md text-black-600 tablet:text-pre-lg pc:text-pre-xl font-semibold"
+                >
                   내용
                 </label>
                 <div className="relative">
-                  <span className="text-pre-lg text-state-error absolute top-[2px] font-medium">*</span>
+                  <span className="text-pre-lg text-state-error tablet:text-pre-lg pc:text-pre-xl absolute top-[2px] font-medium">
+                    *
+                  </span>
                 </div>
               </div>
-              <span className="text-pre-md font-semibold text-blue-400">
+              <span className="text-pre-md tablet:text-pre-lg font-regular flex items-center text-blue-400">
                 {content.length} / {maxLength}자
               </span>
             </div>
             <textarea
               id="content"
-              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl custom-scrollbar h-[132px] w-full resize-none rounded-[12px] border border-blue-300 px-[16px] py-[10px] placeholder:text-blue-400 focus:outline-blue-600"
+              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl custom-scrollbar pc:h-[148px] h-[132px] w-full resize-none rounded-[12px] border border-blue-300 px-[16px] py-[10px] placeholder:text-blue-400 focus:outline-blue-600"
               placeholder="500자 이내로 입력해주세요."
               {...register('content', { required: '내용을 입력해주세요' })}
               value={content}
               onChange={handleInputChange}
             />
           </div>
-          <div className="flex flex-col gap-[8px]">
+          <div className="pc:gap-[16px] flex flex-col gap-[8px]">
             <div className="flex gap-[4px]">
-              <label htmlFor="author" className="text-pre-md text-black-600 font-semibold">
+              <label
+                htmlFor="author"
+                className="text-pre-md text-black-600 tablet:text-pre-lg pc:text-pre-xl font-semibold"
+              >
                 저자
               </label>
               <div className="relative">
@@ -109,8 +128,8 @@ export default function Page() {
                     {...register('authorSelected')}
                     defaultChecked
                   />
-                  <div className="h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
-                  <span className="text-pre-lg text-black-600 font-medium">직접 입력</span>
+                  <div className="pc:h-[24px] pc:w-[24px] pc:peer-checked:border-5 h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
+                  <span className="text-pre-lg text-black-600 pc:text-pre-xl font-medium">직접 입력</span>
                 </label>
                 <label htmlFor="알 수 없음" className="relative flex cursor-pointer items-center gap-[8px]">
                   <input
@@ -120,18 +139,18 @@ export default function Page() {
                     className="peer hidden"
                     {...register('authorSelected')}
                   />
-                  <div className="h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
-                  <span className="text-pre-lg text-black-600 font-medium">알 수 없음</span>
+                  <div className="pc:h-[24px] pc:w-[24px] pc:peer-checked:border-5 h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
+                  <span className="text-pre-lg text-black-600 pc:text-pre-xl font-medium">알 수 없음</span>
                 </label>
                 <label htmlFor="본인" className="relative flex cursor-pointer items-center gap-[8px]">
                   <input id="본인" type="radio" value="본인" className="peer hidden" {...register('authorSelected')} />
-                  <div className="h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
-                  <span className="text-pre-lg text-black-600 font-medium">본인</span>
+                  <div className="pc:h-[24px] pc:w-[24px] pc:peer-checked:border-5 h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
+                  <span className="text-pre-lg text-black-600 pc:text-pre-xl font-medium">본인</span>
                 </label>
               </div>
               <input
                 id="author"
-                className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
+                className={`text-pre-lg font-regular pc:text-pre-xl pc:h-[64px] h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600 ${selectedOption !== '직접 입력' ? 'bg-blue-200 text-blue-400' : 'text-black-950'}`}
                 placeholder="저자 이름 입력"
                 value={author}
                 disabled={selectedOption !== '직접 입력'}
@@ -139,25 +158,31 @@ export default function Page() {
               />
             </div>
           </div>
-          <div className="flex flex-col gap-[8px]">
-            <label htmlFor="referenceTitle" className="text-pre-md text-black-600 font-semibold">
+          <div className="pc:gap-[16px] flex flex-col gap-[8px]">
+            <label
+              htmlFor="referenceTitle"
+              className="text-pre-md text-black-600 tablet:text-pre-lg pc:text-pre-xl font-semibold"
+            >
               출처
             </label>
             <input
               id="referenceTitle"
-              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
+              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl pc:h-[64px] h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
               placeholder="출저 제목 입력"
               {...register('referenceTitle')}
             />
             <input
               id="referenceUrl"
-              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
+              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl pc:h-[64px] h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
               placeholder="URL (ex. https://www.website.com)"
               {...register('referenceUrl')}
             />
           </div>
           <div className="flex flex-col gap-[8px]">
-            <label htmlFor="tags" className="text-pre-md text-black-600 font-semibold">
+            <label
+              htmlFor="tags"
+              className="text-pre-md text-black-600 tablet:text-pre-lg pc:text-pre-xl font-semibold"
+            >
               태그
             </label>
             <TagsInputWithList tags={watch('tags')} setTags={(newTags) => setValue('tags', newTags)} />

--- a/src/app/addepigram/page.tsx
+++ b/src/app/addepigram/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { TagsInputWithList } from '@/components/TagsInputWithList';
 import { PostEpigram } from '@/lib/Epigram';
+import { EpigramTag } from '@/types/Epigram';
 import { ChangeEvent, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
 export interface AddEpigram {
-  tags: string[];
+  tags: EpigramTag[];
   referenceUrl: string;
   referenceTitle: string;
   author: string;
@@ -65,17 +67,22 @@ export default function Page() {
       <form onSubmit={handleSubmit(SubmitForm)} className="flex flex-col gap-[24px]">
         <div className="flex flex-col gap-[40px]">
           <div className="flex flex-col gap-[8px]">
-            <div className="flex gap-[4px]">
-              <label htmlFor="content" className="text-pre-md text-black-600 font-semibold">
-                내용
-              </label>
-              <div className="relative">
-                <span className="text-pre-lg text-state-error absolute top-[2px] font-medium">*</span>
+            <div className="flex justify-between">
+              <div className="flex gap-[4px]">
+                <label htmlFor="content" className="text-pre-md text-black-600 font-semibold">
+                  내용
+                </label>
+                <div className="relative">
+                  <span className="text-pre-lg text-state-error absolute top-[2px] font-medium">*</span>
+                </div>
               </div>
+              <span className="text-pre-md font-semibold text-blue-400">
+                {content.length} / {maxLength}자
+              </span>
             </div>
             <textarea
               id="content"
-              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[132px] resize-none rounded-[12px] border border-blue-300 px-[16px] py-[10px] placeholder:text-blue-400 focus:outline-blue-600"
+              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl custom-scrollbar h-[132px] w-full resize-none rounded-[12px] border border-blue-300 px-[16px] py-[10px] placeholder:text-blue-400 focus:outline-blue-600"
               placeholder="500자 이내로 입력해주세요."
               {...register('content', { required: '내용을 입력해주세요' })}
               value={content}
@@ -83,9 +90,14 @@ export default function Page() {
             />
           </div>
           <div className="flex flex-col gap-[8px]">
-            <label htmlFor="author" className="text-pre-md text-black-600 font-semibold">
-              저자
-            </label>
+            <div className="flex gap-[4px]">
+              <label htmlFor="author" className="text-pre-md text-black-600 font-semibold">
+                저자
+              </label>
+              <div className="relative">
+                <span className="text-pre-lg text-state-error absolute top-[2px] font-medium">*</span>
+              </div>
+            </div>
             <div className="flex flex-col gap-[12px]">
               <div className="flex gap-[16px]">
                 <label htmlFor="직접 입력" className="relative flex cursor-pointer items-center gap-[8px]">
@@ -135,25 +147,20 @@ export default function Page() {
               id="referenceTitle"
               className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
               placeholder="출저 제목 입력"
-              {...register('referenceTitle', { required: '출처를 입력해주세요' })}
+              {...register('referenceTitle')}
             />
             <input
               id="referenceUrl"
               className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
               placeholder="URL (ex. https://www.website.com)"
-              {...register('referenceUrl', { required: 'URL을 입력해주세요' })}
+              {...register('referenceUrl')}
             />
           </div>
           <div className="flex flex-col gap-[8px]">
             <label htmlFor="tags" className="text-pre-md text-black-600 font-semibold">
               태그
             </label>
-            <input
-              id="tags"
-              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
-              placeholder="입력하여 태그 작성 (최대 10자)"
-              {...register('tags', { required: '태그를 입력해주세요' })}
-            />
+            <TagsInputWithList tags={watch('tags')} setTags={(newTags) => setValue('tags', newTags)} />
           </div>
         </div>
         <button

--- a/src/app/addepigram/page.tsx
+++ b/src/app/addepigram/page.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+
+interface AddEpigram {
+  tags: string[];
+  referenceUrl: string;
+  referenceTitle: string;
+  author: string;
+  content: string;
+}
+
+export default function Page() {
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid },
+  } = useForm<AddEpigram>({
+    mode: 'onChange',
+    defaultValues: {
+      tags: [],
+      referenceUrl: '',
+      referenceTitle: '',
+      author: '',
+      content: '',
+    },
+  });
+
+  const SubmitForm = () => {
+    console.log('폼 제출');
+  };
+
+  return (
+    <div className="flex flex-col gap-[24px]">
+      <h1 className="text-pre-lg text-black-700 font-semibold">에피그램 만들기</h1>
+      <form onSubmit={handleSubmit(SubmitForm)} className="flex flex-col gap-[24px]">
+        <div className="flex flex-col gap-[40px]">
+          <div className="flex flex-col gap-[8px]">
+            <div className="flex gap-[4px]">
+              <label htmlFor="content" className="text-pre-md text-black-600 font-semibold">
+                내용
+              </label>
+              <div className="relative">
+                <span className="text-pre-lg text-state-error absolute top-[2px] font-medium">*</span>
+              </div>
+            </div>
+            <textarea
+              id="content"
+              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[132px] resize-none rounded-[12px] border border-blue-300 px-[16px] py-[10px] placeholder:text-blue-400 focus:outline-blue-600"
+              placeholder="500자 이내로 입력해주세요."
+              {...register('content', { required: '내용을 입력해주세요' })}
+            />
+          </div>
+          <div className="flex flex-col gap-[8px]">
+            <label htmlFor="author" className="text-pre-md text-black-600 font-semibold">
+              저자
+            </label>
+            <div className="flex flex-col gap-[12px]">
+              <div className="flex gap-[16px]">
+                <label htmlFor="직접 입력" className="relative flex cursor-pointer items-center gap-[8px]">
+                  <input
+                    id="직접 입력"
+                    name="author"
+                    type="radio"
+                    value="직접 입력"
+                    className="peer hidden"
+                    defaultChecked
+                  />
+                  <div className="h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
+                  <span className="text-pre-lg text-black-600 font-medium">직접 입력</span>
+                </label>
+                <label htmlFor="알 수 없음" className="relative flex cursor-pointer items-center gap-[8px]">
+                  <input id="알 수 없음" name="author" type="radio" value="알 수 없음" className="peer hidden" />
+                  <div className="h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
+                  <span className="text-pre-lg text-black-600 font-medium">알 수 없음</span>
+                </label>
+                <label htmlFor="본인" className="relative flex cursor-pointer items-center gap-[8px]">
+                  <input id="본인" name="author" type="radio" value="본인" className="peer hidden" />
+                  <div className="h-5 w-5 rounded-full border-2 border-blue-300 bg-transparent peer-checked:border-4 peer-checked:border-blue-100 peer-checked:bg-blue-800 peer-checked:shadow-[0_0_0_2px_#CBD3E1]"></div>
+                  <span className="text-pre-lg text-black-600 font-medium">본인</span>
+                </label>
+              </div>
+              <input
+                id="author"
+                className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
+                placeholder="저자 이름 입력"
+                {...register('author', { required: '저자를 입력해주세요' })}
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-[8px]">
+            <label htmlFor="referenceTitle" className="text-pre-md text-black-600 font-semibold">
+              출처
+            </label>
+            <input
+              id="referenceTitle"
+              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
+              placeholder="출저 제목 입력"
+              {...register('referenceTitle', { required: '출처를 입력해주세요' })}
+            />
+            <input
+              id="referenceUrl"
+              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
+              placeholder="URL (ex. https://www.website.com)"
+              {...register('referenceUrl', { required: 'URL을 입력해주세요' })}
+            />
+          </div>
+          <div className="flex flex-col gap-[8px]">
+            <label htmlFor="tags" className="text-pre-md text-black-600 font-semibold">
+              태그
+            </label>
+            <input
+              id="tags"
+              className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
+              placeholder="입력하여 태그 작성 (최대 10자)"
+              {...register('tags', { required: '태그를 입력해주세요' })}
+            />
+          </div>
+        </div>
+        <button
+          className={`text-pre-lg pc:text-pre-xl pc:py-[16px] rounded-[12px] px-[16px] py-[9px] font-semibold text-blue-100 ${isValid ? `bg-black-500 cursor-pointer` : `bg-blue-300`}`}
+          type="submit"
+          disabled={!isValid}
+        >
+          작성완료
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/epigrams/posting/page.tsx
+++ b/src/app/epigrams/posting/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div></div>;
+}

--- a/src/app/epigrams/posting/page.tsx
+++ b/src/app/epigrams/posting/page.tsx
@@ -1,3 +1,0 @@
-export default function Page() {
-  return <div>포스팅</div>;
-}

--- a/src/app/epigrams/posting/page.tsx
+++ b/src/app/epigrams/posting/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <div></div>;
+  return <div>포스팅</div>;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,23 @@ body {
   font-family: "Pretendard Variable", Pretendard, sans-serif;
 }
 
+@layer components {
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 16px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-track {
+
+    margin-right: 10px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background: #ABB8CE;
+    background-clip: padding-box;
+    border-right: 14px solid transparent;
+    border-top: 10px solid transparent;
+    border-bottom: 10px solid transparent;
+  }
+}
+
 @theme {
   --font-iropke: "Iropke Batang", sans-serif; 
   --font-pretendard: 'Pretendard', sans-serif;

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -1,4 +1,5 @@
 import { EpigramTag } from '@/types/Epigram';
+import Image from 'next/image';
 
 interface TagsProps {
   tags: EpigramTag[];
@@ -16,8 +17,12 @@ export function Tags({ tags, onRemoveTag }: TagsProps) {
           <span className="mobile:text-[16px] mobile:leading-[26px] tablet:text-[20px] tablet:leading-[32px] pc:text-[24px] pc:leading-[32px] text-black-300 text-[16px] leading-[26px] font-normal">
             {tag.name}
           </span>
-          <button type="button" onClick={() => onRemoveTag(tag)} className="hover:text-blue-9500 text-blue-500">
-            x
+          <button
+            type="button"
+            onClick={() => onRemoveTag(tag)}
+            className="hover:text-blue-9500 cursor-pointer text-blue-500"
+          >
+            <Image src="/assets/icons/x_gray.svg" width={20} height={20} alt="닫기 아이콘" />
           </button>
         </div>
       ))}

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -33,15 +33,14 @@ export function TagsInput({ onAddTag, tags }: TagsInputProps) {
   };
 
   return (
-    <div className="mobile:gap-[8px] tablet:gap-[8px] pc:gap-[8px] flex items-center gap-2">
-      <input
-        type="text"
-        value={inputValue}
-        onChange={handleInputChange}
-        onKeyDown={handleKeyPress}
-        className="mobile:px-[16px] mobile:py-[8px] mobile:rounded-[12px] mobile:border-[1px] mobile:border-blue-300 mobile:bg-white mobile:text-text-pre-lg mobile:leading-[26px] mobile:font-normal mobile:tracking-[0%] mobile:mb-[15px] tablet:px-[16px] tablet:py-[8px] tablet:rounded-[12px] tablet:border-[1px] tablet:border-blue-300 tablet:bg-white tablet:text-text-pre-lg tablet:leading-[26px] tablet:font-normal tablet:tracking-[0%] tablet:mb-[16px] pc:px-[16px] pc:py-[8px] pc:rounded-[12px] pc:border-[1px] pc:border-blue-300 pc:bg-white pc:text-text-pre-lg pc:leading-[32px] pc:font-normal pc:tracking-[0%] pc:mb-[22px] focus:outline-2 focus:outline-blue-600"
-        placeholder="입력하여 태그 작성 (최대 10자)"
-      />
-    </div>
+    <input
+      id="tags"
+      type="text"
+      value={inputValue}
+      onChange={handleInputChange}
+      onKeyDown={handleKeyPress}
+      className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
+      placeholder="입력하여 태그 작성 (최대 10자)"
+    />
   );
 }

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -12,7 +12,9 @@ export function TagsInput({ onAddTag, tags }: TagsInputProps) {
   const [inputValue, setInputValue] = useState<string>('');
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
+    if (e.target.value.length <= 10) {
+      setInputValue(e.target.value);
+    }
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -39,7 +41,7 @@ export function TagsInput({ onAddTag, tags }: TagsInputProps) {
       value={inputValue}
       onChange={handleInputChange}
       onKeyDown={handleKeyPress}
-      className="text-pre-lg font-regular text-black-950 pc:text-pre-xl h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
+      className="text-pre-lg font-regular text-black-950 pc:text-pre-xl pc:h-[64px] h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"
       placeholder="입력하여 태그 작성 (최대 10자)"
     />
   );

--- a/src/components/TagsInputWithList.tsx
+++ b/src/components/TagsInputWithList.tsx
@@ -1,30 +1,30 @@
 'use client';
 
-import { useState } from 'react';
 import { EpigramTag } from '@/types/Epigram';
 import { TagsInput } from './TagsInput';
 import { Tags } from './Tags';
 
-export function TagsInputWithList() {
-  const [tags, setTags] = useState<EpigramTag[]>([]); // 초기값 없이 빈배열로 시작
-
+export function TagsInputWithList({ tags, setTags }: { tags: EpigramTag[]; setTags: (tags: EpigramTag[]) => void }) {
   const handleAddTag = (newTag: EpigramTag) => {
-    // 중복 태그 체크
-    const isDuplicate = tags.some((tag) => tag.name === newTag.name);
-    if (isDuplicate) {
+    if (tags.some((tag) => tag.name === newTag.name)) {
       alert('이 태그는 이미 추가되어 있습니다.');
-      return; // 중복이 있을 경우 추가하지 않음
+      return;
     }
-
-    setTags([...tags, newTag]); // 새로운 태그 추가
+    if (tags.length >= 3) {
+      alert('태그는 최대 3개까지 가능합니다.');
+      return;
+    }
+    const updatedTags = [...tags, newTag];
+    setTags(updatedTags); // react-hook-form 상태 업데이트
   };
 
   const handleRemoveTag = (tag: EpigramTag) => {
-    setTags(tags.filter((t) => t.id !== tag.id)); // 태그 삭제
+    const updatedTags = tags.filter((t) => t.id !== tag.id);
+    setTags(updatedTags); // react-hook-form 상태 업데이트
   };
 
   return (
-    <div>
+    <div className="flex flex-col gap-[15px]">
       <TagsInput onAddTag={handleAddTag} tags={tags} />
       <Tags tags={tags} onRemoveTag={handleRemoveTag} />
     </div>

--- a/src/lib/Epigram.ts
+++ b/src/lib/Epigram.ts
@@ -5,15 +5,17 @@ import { EpigramList } from '@/types/Epigram';
 export async function PostEpigram(epigrams: AddEpigram) {
   const { tags, referenceUrl, referenceTitle, author, content } = epigrams;
 
+  const tagslist = tags.map((item) => item.name);
+
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/emotionLogs/today`, {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/epigrams`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer 토큰`,
       },
       body: JSON.stringify({
-        tags: tags,
+        tags: tagslist,
         referenceUrl: referenceUrl,
         referenceTitle: referenceTitle,
         author: author,

--- a/src/lib/Epigram.ts
+++ b/src/lib/Epigram.ts
@@ -1,6 +1,7 @@
 import { AddEpigram } from '@/app/addepigram/page';
+import { EpigramList } from '@/types/Epigram';
 
-// 에피그램 API
+// 에피그램 post
 export async function PostEpigram(epigrams: AddEpigram) {
   const { tags, referenceUrl, referenceTitle, author, content } = epigrams;
 
@@ -37,7 +38,6 @@ export async function PostEpigram(epigrams: AddEpigram) {
     }
   }
 }
-import { EpigramList } from '@/types/Epigram';
 
 // 에피그램 목록 조회
 export async function getEpigramsList(

--- a/src/lib/Epigram.ts
+++ b/src/lib/Epigram.ts
@@ -1,3 +1,42 @@
+import { AddEpigram } from '@/app/addepigram/page';
+
+// 에피그램 API
+export async function PostEpigram(epigrams: AddEpigram) {
+  const { tags, referenceUrl, referenceTitle, author, content } = epigrams;
+
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/emotionLogs/today`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer 토큰`,
+      },
+      body: JSON.stringify({
+        tags: tags,
+        referenceUrl: referenceUrl,
+        referenceTitle: referenceTitle,
+        author: author,
+        content: content,
+      }),
+    });
+
+    if (response.status === 401) {
+      throw new Error('로그인이 만료되었습니다.');
+    }
+
+    if (!response.ok || response === null) {
+      throw new Error('서버 오류가 발생하였습니다.');
+    }
+    const data = response.json();
+    return data;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error(`${error.message}`);
+    } else {
+      console.error('에피그램을 등록하는데 실패했습니다.');
+    }
+  }
+}
 import { EpigramList } from '@/types/Epigram';
 
 // 에피그램 목록 조회


### PR DESCRIPTION
## #️⃣ 이슈

- close #58 

## 📝 작업 내용

/addepigram 페이지의 에피그램을 작성할 수 있는 페이지 입니다.
현재 값 입력을 받고 api에 토큰을 넣으면 POST요청까지 가능한 상태입니다.

게시글 수정의 경우 initialValue값을 전달하려면 게시글과 수정글이 부모자식 관계여야하는데,
저희는 페이지 위치가 아예 다르기 때문에 이를 어떻게 전달할지 의논이 필요할 것 같습니다.

생각하고 있는 방식은 총 2가지 입니다.
1. 에피그램 상세페이지에서 수정하기 클릭시 useRouter로 페이지 이동 => /addepigram/[id].tsx 로 id값을 활용하여 api요청을 보내 getEpigram으로 초깃값 가져오기. 

2. Context를 활용하여 에피그램 값을 전역으로 관리하기 => 에피그램 상세페이지에서 수정하기 클릭시 useRouter로 페이지 이동 => Context로 필요한 값 가져오기.

UI디자인은 완성된 상태입니다.
content내용은 500자로 제한했으며,그 이상으로는 작성할 수 없도록 막아뒀습니다. 500자를 넘어가면 경고메세지를 띄우는것 보다는, 실시간으로 작성중인 글자수를 오른쪽위에 띄워주는 편이 직관적이라고 생각하여 추가했습니다.

global.css에 커스텀 스크롤바를 만들어뒀으니 필요하실때 쓰시면 됩니다.

현재 빌드오류는 제 페이지의 문제가 아닌 것 같아 이대로 올려둡니다!

## 📸 결과물


https://github.com/user-attachments/assets/4d7c3876-d46e-402c-96b6-5a25255541db



## 👩‍💻 공유 포인트 및 논의 사항

- 게시글 수정시 initialValue값을 전달 방식

