### PR TITLE
feat(#100): 마이페이지 댓글컴포넌트 구현

### DIFF
--- a/src/app/mypage/_components/MyCommentList.tsx
+++ b/src/app/mypage/_components/MyCommentList.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { getComments } from '@/lib/Comment';
+import { CommentList, Comment } from '@/types/Comment';
+import { CommentItem } from '@/components/Comment/CommentItem';
+
+export default function MyCommentList() {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [nextCursor, setNextCursor] = useState<number | null>(0);
+
+  const testToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTU3NywidGVhbUlkIjoiMTItNSIsInNjb3BlIjoiYWNjZXNzIiwiaWF0IjoxNzQzMTE4NjA1LCJleHAiOjE3NDMxMjA0MDUsImlzcyI6InNwLWVwaWdyYW0ifQ.u92whf7QMq2PjziwyNRhQTti_xvz4e3FfCpMJ5mjUj8';
+
+  useEffect(() => {
+    const fetchComments = async () => {
+      try {
+        if (nextCursor === null) return;
+
+        // 전체 댓글을 가져옵니다 (여기서는 100이 아니라 전체 댓글을 가져오는 코드로 수정됨)
+        const response: CommentList = await getComments(testToken, 100, nextCursor);
+        const userId = JSON.parse(atob(testToken.split('.')[1])).id;
+
+        // 전체 댓글에서 내 댓글만 필터링
+        const myComments: Comment[] = response.list.filter((comment: Comment) => Number(comment.writer.id) === userId);
+
+        if (myComments.length === 0) return;
+
+        setComments(myComments.slice(0, 4));
+        setNextCursor(response.nextCursor);
+      } catch (error) {
+        console.error('댓글 불러오기 실패:', error);
+      }
+    };
+
+    fetchComments();
+  }, [nextCursor]); // nextCursor가 변경되면 다시 실행
+
+  return (
+    <div className="w-full">
+      {comments.map((comment) => (
+        <CommentItem
+          key={comment.id}
+          comment={comment}
+          token={testToken}
+          onDelete={(id) => setComments((prev) => prev.filter((c) => c.id !== id))} // 삭제 시 필터링
+          onSave={(updated) => setComments((prev) => prev.map((c) => (c.id === updated.id ? updated : c)))} // 수정 시 상태 업데이트
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/sample/_components/Jin.tsx
+++ b/src/app/sample/_components/Jin.tsx
@@ -2,6 +2,7 @@
 
 import LatestCommentSection from '@/app/epigrams/_component/LatestCommentSection';
 import EpigramCommentSection from '@/app/feed/[id]/_component/EpigramCommentSection';
+import MyCommentList from '@/app/mypage/_components/MyCommentList';
 import { SessionProvider } from 'next-auth/react';
 
 export default function Jin() {
@@ -14,9 +15,12 @@ export default function Jin() {
           <LatestCommentSection />
           <br></br>
           <EpigramCommentSection
-            epigramId={1096}
-            token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTU3NywidGVhbUlkIjoiMTItNSIsInNjb3BlIjoiYWNjZXNzIiwiaWF0IjoxNzQyOTM2ODUwLCJleHAiOjE3NDI5Mzg2NTAsImlzcyI6InNwLWVwaWdyYW0ifQ.s0BjZDNdS5K_8VTwBYWrzhTG7G2vK2prfaiXbPlMAuI"
+            epigramId={1067}
+            token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTU0NywidGVhbUlkIjoiMTItNSIsInNjb3BlIjoiYWNjZXNzIiwiaWF0IjoxNzQzMDI1OTk0LCJleHAiOjE3NDMwMjc3OTQsImlzcyI6InNwLWVwaWdyYW0ifQ.aUPn33DCvlJC_A49S04cSzQ5qprul93-ROjPJypgR18"
           />
+          <br></br>
+          <h1>내 댓글 목록</h1>
+          <MyCommentList />
         </div>
       </div>
     </SessionProvider>

--- a/src/components/Comment/CommentList.tsx
+++ b/src/components/Comment/CommentList.tsx
@@ -9,7 +9,7 @@ export default function CommentList() {
   const [comments, setComments] = useState<Comment[]>([]);
 
   const testToken =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTU3NywidGVhbUlkIjoiMTItNSIsInNjb3BlIjoiYWNjZXNzIiwiaWF0IjoxNzQyOTM2ODUwLCJleHAiOjE3NDI5Mzg2NTAsImlzcyI6InNwLWVwaWdyYW0ifQ.s0BjZDNdS5K_8VTwBYWrzhTG7G2vK2prfaiXbPlMAuI';
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTU0NywidGVhbUlkIjoiMTItNSIsInNjb3BlIjoiYWNjZXNzIiwiaWF0IjoxNzQzMDI1OTk0LCJleHAiOjE3NDMwMjc3OTQsImlzcyI6InNwLWVwaWdyYW0ifQ.aUPn33DCvlJC_A49S04cSzQ5qprul93-ROjPJypgR18';
 
   useEffect(() => {
     const fetchComments = async () => {

--- a/src/lib/Comment.ts
+++ b/src/lib/Comment.ts
@@ -1,5 +1,7 @@
 // 코멘트 API
 
+import { CommentList } from '@/types/Comment';
+
 // 댓글 작성
 export async function createComment(token: string, epigramId: number, content: string, isPrivate: boolean) {
   const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/comments`, {
@@ -31,7 +33,8 @@ export async function getComments(token: string, limit: number, cursor: number, 
   });
 
   if (!response.ok) throw new Error('댓글 불러오기 실패');
-  return await response.json();
+  const data: CommentList = await response.json();
+  return data;
 }
 
 // 댓글 수정


### PR DESCRIPTION
## #️⃣ 이슈

- close #100 

## 📝 작업 내용
1. 마이페이지 댓글컴포넌트 구현
(writer.id 로 유저id에 해당하는 내댓글 목록 리스트가 조회되도록 구현)

## 📸 결과물

https://github.com/user-attachments/assets/d094e313-43d7-4b5b-880c-a334411627c9
테스트로 토큰을 넣으면 해당 토큰의 정보 id에 대한 유저의 댓글이 필터로인해 조회가 됩니다.

## 👩‍💻 공유 포인트 및 논의 사항
지금 현재 더보기 버튼은 따로 구현을 안했습니다.
한솔님께서 만드신 더보기 버튼 적용 추가로 하도록 하겠습니다.
현재는 딱 해당 유저id에 해당하는 댓글 리스트만 조회되도록 구현)