### PR TITLE
Feat(#94): 마이페이지 캘린더

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,11 +30,8 @@
         "react-cookie": "^8.0.1",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
-<<<<<<< HEAD
         "react-toastify": "^11.0.5",
         "recharts": "^2.15.1",
-=======
->>>>>>> 23e40a0 (Feat: 캘린더 유저log 가져오기)
         "zod": "^3.24.2",
         "zustand": "^5.0.3"
       },
@@ -4424,10 +4421,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 23e40a0 (Feat: 캘린더 유저log 가져오기)
       "engines": {
         "node": ">=6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,8 @@
         "framer-motion": "^12.5.0",
         "google-auth-library": "^9.15.1",
         "js-cookie": "^3.0.5",
-<<<<<<< HEAD
         "lightningcss": "^1.29.3",
-=======
         "moment": "^2.30.1",
->>>>>>> 685ee2d (Feat: 캘린더 유저log 가져오기)
         "motion": "^12.5.0",
         "next": "15.2.1",
         "next-auth": "^5.0.0-beta.25",
@@ -2033,7 +2030,6 @@
         "@tailwindcss/oxide-win32-x64-msvc": "4.0.17"
       }
     },
-<<<<<<< HEAD
     "node_modules/@tailwindcss/oxide-android-arm64": {
       "version": "4.0.17",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.17.tgz",
@@ -2194,8 +2190,6 @@
         "node": ">= 10"
       }
     },
-=======
->>>>>>> 685ee2d (Feat: 캘린더 유저log 가져오기)
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
       "version": "4.0.17",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.17.tgz",
@@ -7425,7 +7419,6 @@
         "lightningcss-win32-x64-msvc": "1.29.3"
       }
     },
-<<<<<<< HEAD
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.29.3",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.3.tgz",
@@ -7606,8 +7599,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-=======
->>>>>>> 685ee2d (Feat: 캘린더 유저log 가져오기)
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.29.3",
       "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,16 +17,24 @@
         "framer-motion": "^12.5.0",
         "google-auth-library": "^9.15.1",
         "js-cookie": "^3.0.5",
+<<<<<<< HEAD
         "lightningcss": "^1.29.3",
+=======
+        "moment": "^2.30.1",
+>>>>>>> 685ee2d (Feat: 캘린더 유저log 가져오기)
         "motion": "^12.5.0",
         "next": "15.2.1",
         "next-auth": "^5.0.0-beta.25",
         "react": "^19.0.0",
+        "react-calendar": "^5.1.0",
         "react-cookie": "^8.0.1",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
+<<<<<<< HEAD
         "react-toastify": "^11.0.5",
         "recharts": "^2.15.1",
+=======
+>>>>>>> 23e40a0 (Feat: 캘린더 유저log 가져오기)
         "zod": "^3.24.2",
         "zustand": "^5.0.3"
       },
@@ -2028,6 +2036,7 @@
         "@tailwindcss/oxide-win32-x64-msvc": "4.0.17"
       }
     },
+<<<<<<< HEAD
     "node_modules/@tailwindcss/oxide-android-arm64": {
       "version": "4.0.17",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.17.tgz",
@@ -2188,6 +2197,8 @@
         "node": ">= 10"
       }
     },
+=======
+>>>>>>> 685ee2d (Feat: 캘린더 유저log 가져오기)
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
       "version": "4.0.17",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.17.tgz",
@@ -3595,6 +3606,14 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -4405,7 +4424,10 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+<<<<<<< HEAD
       "license": "MIT",
+=======
+>>>>>>> 23e40a0 (Feat: 캘린더 유저log 가져오기)
       "engines": {
         "node": ">=6"
       }
@@ -6182,6 +6204,17 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
+      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -7398,6 +7431,7 @@
         "lightningcss-win32-x64-msvc": "1.29.3"
       }
     },
+<<<<<<< HEAD
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.29.3",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.3.tgz",
@@ -7578,6 +7612,8 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+=======
+>>>>>>> 685ee2d (Feat: 캘린더 유저log 가져오기)
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.29.3",
       "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.3.tgz",
@@ -7701,6 +7737,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/map-or-similar": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
@@ -7715,6 +7762,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
     "node_modules/memoizerific": {
@@ -7785,6 +7847,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -7834,6 +7904,14 @@
       "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/motion": {
       "version": "12.5.0",
@@ -8346,6 +8424,14 @@
         "@oxc-resolver/binding-win32-x64-msvc": "5.0.0"
       }
     },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8849,6 +8935,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.1.0.tgz",
+      "integrity": "sha512-09o/rQHPZGEi658IXAJtWfra1N69D1eFnuJ3FQm9qUVzlzNnos1+GWgGiUeSs22QOpNm32aoVFOimq0p3Ug9Eg==",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^2.2.1",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-confetti": {
@@ -10827,6 +10937,14 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -11212,7 +11330,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
       "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
-      "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,11 +21,8 @@
     "framer-motion": "^12.5.0",
     "google-auth-library": "^9.15.1",
     "js-cookie": "^3.0.5",
-<<<<<<< HEAD
     "lightningcss": "^1.29.3",
-=======
     "moment": "^2.30.1",
->>>>>>> 685ee2d (Feat: 캘린더 유저log 가져오기)
     "motion": "^12.5.0",
     "next": "15.2.1",
     "next-auth": "^5.0.0-beta.25",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,16 @@
     "framer-motion": "^12.5.0",
     "google-auth-library": "^9.15.1",
     "js-cookie": "^3.0.5",
+<<<<<<< HEAD
     "lightningcss": "^1.29.3",
+=======
+    "moment": "^2.30.1",
+>>>>>>> 685ee2d (Feat: 캘린더 유저log 가져오기)
     "motion": "^12.5.0",
     "next": "15.2.1",
     "next-auth": "^5.0.0-beta.25",
     "react": "^19.0.0",
+    "react-calendar": "^5.1.0",
     "react-cookie": "^8.0.1",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",

--- a/public/assets/icons/down_gray.svg
+++ b/public/assets/icons/down_gray.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 6L8 10L12 6" stroke="#C4C4C4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/mypage/_components/MyCalender/CustomCalender.tsx
+++ b/src/app/mypage/_components/MyCalender/CustomCalender.tsx
@@ -6,18 +6,7 @@ import './custom-calendar.css';
 import moment from 'moment';
 import { JSX, useState } from 'react';
 import { EmotionLog } from '@/types/Emotionlog';
-import EmotionFilter, { EmotionKey } from './EmotionFilter';
-
-const EmotionData = {
-  MOVED: {
-    image: '/assets/images/heartFace.png',
-    name: '감동',
-  },
-  HAPPY: { image: '/assets/images/smiling.png', name: '기쁨' },
-  WORRIED: { image: '/assets/images/thinking.png', name: '걱정' },
-  SAD: { image: '/assets/images/sad.png', name: '슬픔' },
-  ANGRY: { image: '/assets/images/angry.png', name: '화남' },
-};
+import EmotionFilter, { EmotionData, EmotionKey } from './EmotionFilter';
 
 export default function CustomCalender({
   data,

--- a/src/app/mypage/_components/MyCalender/CustomCalender.tsx
+++ b/src/app/mypage/_components/MyCalender/CustomCalender.tsx
@@ -6,22 +6,28 @@ import './custom-calendar.css';
 import moment from 'moment';
 import { JSX, useState } from 'react';
 import { EmotionLog } from '@/types/Emotionlog';
+import EmotionFilter, { EmotionKey } from './EmotionFilter';
 
 type ValuePiece = Date | null;
 
 type Value = ValuePiece | [ValuePiece, ValuePiece];
 
 const EmotionData = {
-  MOVED: '/assets/images/heartFace.png',
-  HAPPY: '/assets/images/smiling.png',
-  WORRIED: '/assets/images/thinking.png',
-  SAD: '/assets/images/sad.png',
-  ANGRY: '/assets/images/angry.png',
+  MOVED: {
+    image: '/assets/images/heartFace.png',
+    name: '감동',
+  },
+  HAPPY: { image: '/assets/images/smiling.png', name: '기쁨' },
+  WORRIED: { image: '/assets/images/thinking.png', name: '걱정' },
+  SAD: { image: '/assets/images/sad.png', name: '슬픔' },
+  ANGRY: { image: '/assets/images/angry.png', name: '화남' },
 };
 
 export default function CustomCalender({ data }: { data: EmotionLog[] }) {
   const [value, onChange] = useState<Value>(new Date());
   const [displayMonth, setDisplayMonth] = useState<Date>(new Date());
+  const [isFilterVisible, setIsFilterVisible] = useState<boolean>(false);
+  const [selectedEmotion, setSelectedEmotion] = useState<EmotionKey | null>(null);
   const createdAtArray = data.map((item) => moment(item.createdAt).format('YYYY-MM-DD'));
 
   const goToNextMonth = () => {
@@ -34,12 +40,16 @@ export default function CustomCalender({ data }: { data: EmotionLog[] }) {
     setDisplayMonth(prevMonth);
   };
 
+  const toggleFilter = () => {
+    setIsFilterVisible((prev) => !prev);
+  };
+
   const addContent = ({ date }: { date: Date | string }) => {
     const contents: JSX.Element[] = [];
     data.map((day) => {
       if (moment(day.createdAt).format('YYYY-MM-DD') === moment(date).format('YYYY-MM-DD')) {
         contents.push(
-          <Image key={day.id} src={`${EmotionData[day.emotion]}`} width="24" height="24" alt="오늘의 감정" />,
+          <Image key={day.id} src={`${EmotionData[day.emotion].image}`} width="24" height="24" alt="오늘의 감정" />,
         );
       }
     });
@@ -48,12 +58,17 @@ export default function CustomCalender({ data }: { data: EmotionLog[] }) {
 
   return (
     <div className="flex w-full flex-col items-center justify-center gap-[22px]">
-      <div className="flex w-[312px] items-center justify-between">
+      <div className="relative flex w-[312px] items-center justify-between">
         <span className="text-pre-lg text-black-600 font-semibold">{moment(displayMonth).format('YYYY년 M월')}</span>
         <div className="flex gap-[16px]">
-          <div className="bg-bg-100 flex items-center justify-center gap-[4px] rounded-[8px] py-[5px] pr-[8px] pl-[12px]">
-            <span className="text-pre-xs font-semibold text-gray-200">필터: 없음</span>
-            <Image src="/assets/icons/down.svg" width={16} height={16} alt="토글" />
+          <div
+            onClick={toggleFilter}
+            className={`bg-bg-100 flex h-[30px] w-[88px] cursor-pointer items-center justify-center gap-[4px] rounded-[8px] py-[5px] ${selectedEmotion ? 'border-black-600 border-[3px] pr-[5px] pl-[9px]' : 'pr-[8px] pl-[12px]'}`}
+          >
+            <span className={`text-pre-xs font-semibold ${selectedEmotion ? 'text-black-600' : 'text-gray-200'}`}>
+              필터: {selectedEmotion ? `${EmotionData[selectedEmotion].name}` : '없음'}
+            </span>
+            <Image src={`/assets/icons/down${selectedEmotion ? '' : '_gray'}.svg`} width={16} height={16} alt="토글" />
           </div>
           <Image
             className="cursor-pointer"
@@ -72,6 +87,7 @@ export default function CustomCalender({ data }: { data: EmotionLog[] }) {
             alt="오른쪽 버튼"
           />
         </div>
+        {isFilterVisible && <EmotionFilter selectedEmotion={selectedEmotion} setSelectedEmotion={setSelectedEmotion} />}
       </div>
       <Calendar
         locale="ko"

--- a/src/app/mypage/_components/MyCalender/CustomCalender.tsx
+++ b/src/app/mypage/_components/MyCalender/CustomCalender.tsx
@@ -8,10 +8,6 @@ import { JSX, useState } from 'react';
 import { EmotionLog } from '@/types/Emotionlog';
 import EmotionFilter, { EmotionKey } from './EmotionFilter';
 
-type ValuePiece = Date | null;
-
-type Value = ValuePiece | [ValuePiece, ValuePiece];
-
 const EmotionData = {
   MOVED: {
     image: '/assets/images/heartFace.png',
@@ -23,12 +19,19 @@ const EmotionData = {
   ANGRY: { image: '/assets/images/angry.png', name: '화남' },
 };
 
-export default function CustomCalender({ data }: { data: EmotionLog[] }) {
-  const [value, onChange] = useState<Value>(new Date());
-  const [displayMonth, setDisplayMonth] = useState<Date>(new Date());
+export default function CustomCalender({
+  data,
+  displayMonth,
+  setDisplayMonth,
+}: {
+  data: EmotionLog[];
+  displayMonth: Date;
+  setDisplayMonth: React.Dispatch<React.SetStateAction<Date>>;
+}) {
   const [isFilterVisible, setIsFilterVisible] = useState<boolean>(false);
   const [selectedEmotion, setSelectedEmotion] = useState<EmotionKey | null>(null);
-  const createdAtArray = data.map((item) => moment(item.createdAt).format('YYYY-MM-DD'));
+  const filteredData = data.filter((item) => selectedEmotion === null || item.emotion === selectedEmotion);
+  const createdAtArray = filteredData.map((item) => moment(item.createdAt).format('YYYY-MM-DD'));
 
   const goToNextMonth = () => {
     const nextMonth = moment(displayMonth).add(1, 'month').toDate();
@@ -46,7 +49,8 @@ export default function CustomCalender({ data }: { data: EmotionLog[] }) {
 
   const addContent = ({ date }: { date: Date | string }) => {
     const contents: JSX.Element[] = [];
-    data.map((day) => {
+
+    filteredData.map((day) => {
       if (moment(day.createdAt).format('YYYY-MM-DD') === moment(date).format('YYYY-MM-DD')) {
         contents.push(
           <Image key={day.id} src={`${EmotionData[day.emotion].image}`} width="24" height="24" alt="오늘의 감정" />,
@@ -92,8 +96,7 @@ export default function CustomCalender({ data }: { data: EmotionLog[] }) {
       <Calendar
         locale="ko"
         formatDay={(local, date) => moment(date).format('D')}
-        value={value}
-        onChange={onChange}
+        value={new Date()}
         next2Label={null}
         prev2Label={null}
         tileContent={addContent}

--- a/src/app/mypage/_components/MyCalender/CustomCalender.tsx
+++ b/src/app/mypage/_components/MyCalender/CustomCalender.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import Image from 'next/image';
+import Calendar from 'react-calendar';
+import './custom-calendar.css';
+import moment from 'moment';
+import { JSX, useState } from 'react';
+import { EmotionLog } from '@/types/Emotionlog';
+
+type ValuePiece = Date | null;
+
+type Value = ValuePiece | [ValuePiece, ValuePiece];
+
+const EmotionData = {
+  MOVED: '/assets/images/heartFace.png',
+  HAPPY: '/assets/images/smiling.png',
+  WORRIED: '/assets/images/thinking.png',
+  SAD: '/assets/images/sad.png',
+  ANGRY: '/assets/images/angry.png',
+};
+
+export default function CustomCalender({ data }: { data: EmotionLog[] }) {
+  const [value, onChange] = useState<Value>(new Date());
+  const [displayMonth, setDisplayMonth] = useState<Date>(new Date());
+  const createdAtArray = data.map((item) => moment(item.createdAt).format('YYYY-MM-DD'));
+
+  const goToNextMonth = () => {
+    const nextMonth = moment(displayMonth).add(1, 'month').toDate();
+    setDisplayMonth(nextMonth);
+  };
+
+  const goToPrevMonth = () => {
+    const prevMonth = moment(displayMonth).subtract(1, 'month').toDate();
+    setDisplayMonth(prevMonth);
+  };
+
+  const addContent = ({ date }: { date: Date | string }) => {
+    const contents: JSX.Element[] = [];
+    data.map((day) => {
+      if (moment(day.createdAt).format('YYYY-MM-DD') === moment(date).format('YYYY-MM-DD')) {
+        contents.push(
+          <Image key={day.id} src={`${EmotionData[day.emotion]}`} width="24" height="24" alt="오늘의 감정" />,
+        );
+      }
+    });
+    return <div className="flex items-center justify-center">{contents}</div>;
+  };
+
+  return (
+    <div className="flex w-full flex-col items-center justify-center gap-[22px]">
+      <div className="flex w-[312px] items-center justify-between">
+        <span className="text-pre-lg text-black-600 font-semibold">{moment(displayMonth).format('YYYY년 M월')}</span>
+        <div className="flex gap-[16px]">
+          <div className="bg-bg-100 flex items-center justify-center gap-[4px] rounded-[8px] py-[5px] pr-[8px] pl-[12px]">
+            <span className="text-pre-xs font-semibold text-gray-200">필터: 없음</span>
+            <Image src="/assets/icons/down.svg" width={16} height={16} alt="토글" />
+          </div>
+          <Image
+            className="cursor-pointer"
+            onClick={goToPrevMonth}
+            src="/assets/icons/left.svg"
+            width={20}
+            height={20}
+            alt="왼쪽 버튼"
+          />
+          <Image
+            className="cursor-pointer"
+            onClick={goToNextMonth}
+            src="/assets/icons/right.svg"
+            width={20}
+            height={20}
+            alt="오른쪽 버튼"
+          />
+        </div>
+      </div>
+      <Calendar
+        locale="ko"
+        formatDay={(local, date) => moment(date).format('D')}
+        value={value}
+        onChange={onChange}
+        next2Label={null}
+        prev2Label={null}
+        tileContent={addContent}
+        className={`w-[312px] rounded-xl bg-white`}
+        tileClassName={({ date, view }) => {
+          const dateString = moment(date).format('YYYY-MM-DD');
+          const isSpecialDay = createdAtArray.includes(dateString);
+
+          return view === 'month'
+            ? `font-semibold text-gray-200 w-[44px] h-[44px] flex flex-col justify-center items-center text-center border-b border-blue-200 ${isSpecialDay ? 'text-[8px]' : 'text-pre-lg'}`
+            : '';
+        }}
+        nextLabel={null}
+        prevLabel={null}
+        activeStartDate={displayMonth}
+      />
+    </div>
+  );
+}

--- a/src/app/mypage/_components/MyCalender/CustomCalender.tsx
+++ b/src/app/mypage/_components/MyCalender/CustomCalender.tsx
@@ -53,7 +53,14 @@ export default function CustomCalender({
     filteredData.map((day) => {
       if (moment(day.createdAt).format('YYYY-MM-DD') === moment(date).format('YYYY-MM-DD')) {
         contents.push(
-          <Image key={day.id} src={`${EmotionData[day.emotion].image}`} width="24" height="24" alt="오늘의 감정" />,
+          <div key={day.id} className="pc:w-[36px] pc:h-[36px] relative h-[24px] w-[24px]">
+            <Image
+              src={`${EmotionData[day.emotion].image}`}
+              fill
+              alt="오늘의 감정"
+              sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 100px"
+            />
+          </div>,
         );
       }
     });
@@ -62,34 +69,42 @@ export default function CustomCalender({
 
   return (
     <div className="flex w-full flex-col items-center justify-center gap-[22px]">
-      <div className="relative flex w-[312px] items-center justify-between">
-        <span className="text-pre-lg text-black-600 font-semibold">{moment(displayMonth).format('YYYY년 M월')}</span>
-        <div className="flex gap-[16px]">
+      <div className="relative flex w-full items-center justify-between">
+        <span className="text-pre-lg text-black-600 pc:text-pre-2xl font-semibold">
+          {moment(displayMonth).format('YYYY년 M월')}
+        </span>
+        <div className="flex items-center justify-center gap-[16px]">
           <div
             onClick={toggleFilter}
-            className={`bg-bg-100 flex h-[30px] w-[88px] cursor-pointer items-center justify-center gap-[4px] rounded-[8px] py-[5px] ${selectedEmotion ? 'border-black-600 border-[3px] pr-[5px] pl-[9px]' : 'pr-[8px] pl-[12px]'}`}
+            className={`bg-bg-100 pc:h-[52px] pc:w-[144px] pc:rounded-[14px] flex h-[30px] w-[88px] cursor-pointer items-center justify-center gap-[4px] rounded-[8px] py-[5px] ${selectedEmotion ? 'border-black-600 border-[3px] pr-[5px] pl-[9px]' : 'pr-[8px] pl-[12px]'}`}
           >
-            <span className={`text-pre-xs font-semibold ${selectedEmotion ? 'text-black-600' : 'text-gray-200'}`}>
+            <span
+              className={`text-pre-xs pc:text-pre-xl font-semibold ${selectedEmotion ? 'text-black-600' : 'text-gray-200'}`}
+            >
               필터: {selectedEmotion ? `${EmotionData[selectedEmotion].name}` : '없음'}
             </span>
-            <Image src={`/assets/icons/down${selectedEmotion ? '' : '_gray'}.svg`} width={16} height={16} alt="토글" />
+            <div className="pc:w-[36px] pc:h-[36px] relative h-[16px] w-[16px]">
+              <Image src={`/assets/icons/down${selectedEmotion ? '' : '_gray'}.svg`} fill alt="토글" />
+            </div>
           </div>
-          <Image
-            className="cursor-pointer"
-            onClick={goToPrevMonth}
-            src="/assets/icons/left.svg"
-            width={20}
-            height={20}
-            alt="왼쪽 버튼"
-          />
-          <Image
-            className="cursor-pointer"
-            onClick={goToNextMonth}
-            src="/assets/icons/right.svg"
-            width={20}
-            height={20}
-            alt="오른쪽 버튼"
-          />
+          <div className="pc:w-[36px] pc:h-[36px] relative h-[20px] w-[20px]">
+            <Image
+              className="cursor-pointer"
+              onClick={goToPrevMonth}
+              src="/assets/icons/left.svg"
+              fill
+              alt="왼쪽 버튼"
+            />
+          </div>
+          <div className="pc:w-[36px] pc:h-[36px] relative h-[20px] w-[20px]">
+            <Image
+              className="cursor-pointer"
+              onClick={goToNextMonth}
+              src="/assets/icons/right.svg"
+              fill
+              alt="오른쪽 버튼"
+            />
+          </div>
         </div>
         {isFilterVisible && <EmotionFilter selectedEmotion={selectedEmotion} setSelectedEmotion={setSelectedEmotion} />}
       </div>
@@ -100,13 +115,13 @@ export default function CustomCalender({
         next2Label={null}
         prev2Label={null}
         tileContent={addContent}
-        className={`w-[312px] rounded-xl bg-white`}
+        className={`tablet:w-[379px] pc:w-[637px] w-[308px] rounded-xl bg-white`}
         tileClassName={({ date, view }) => {
           const dateString = moment(date).format('YYYY-MM-DD');
           const isSpecialDay = createdAtArray.includes(dateString);
 
           return view === 'month'
-            ? `font-semibold text-gray-200 w-[44px] h-[44px] flex flex-col justify-center items-center text-center border-b border-blue-200 ${isSpecialDay ? 'text-[8px]' : 'text-pre-lg'}`
+            ? `font-semibold text-gray-200 w-[44px] h-[44px] tablet:w-[54px] tablet:h-[54px] pc:w-[91px] pc:h-[91px] flex flex-col justify-center items-center text-center border-b border-blue-200 pc:text-pre-2xl ${isSpecialDay ? 'text-[8px] pc:text-[16px]' : 'text-pre-lg'}`
             : '';
         }}
         nextLabel={null}

--- a/src/app/mypage/_components/MyCalender/EmotionFilter.tsx
+++ b/src/app/mypage/_components/MyCalender/EmotionFilter.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import Image from 'next/image';
+
+const EmotionData = {
+  MOVED: {
+    image: '/assets/images/heartFace.png',
+    name: '감동',
+  },
+  HAPPY: { image: '/assets/images/smiling.png', name: '기쁨' },
+  WORRIED: { image: '/assets/images/thinking.png', name: '걱정' },
+  SAD: { image: '/assets/images/sad.png', name: '슬픔' },
+  ANGRY: { image: '/assets/images/angry.png', name: '화남' },
+};
+
+export type EmotionKey = keyof typeof EmotionData;
+
+function Emotion({
+  emotion,
+  isSelected,
+  onClick,
+}: {
+  emotion: EmotionKey;
+  isSelected: boolean;
+  onClick: (key: EmotionKey) => void;
+}) {
+  return (
+    <div className="flex cursor-pointer flex-col items-center gap-[8px]" onClick={() => onClick(emotion)}>
+      <div
+        className={`tablet:h-[64px] tablet:w-[64px] pc:w-[96px] pc:h-[96px] flex h-[48px] w-[48px] items-center justify-center rounded-[8px] ${isSelected ? `relative` : `bg-[#AFBACD]/15`}`}
+      >
+        <div className="pc:h-[48px] pc:w-[48px] relative h-[32px] w-[32px] object-contain">
+          <Image
+            priority
+            src={EmotionData[emotion].image}
+            fill
+            alt={`${emotion} 아이콘`}
+            sizes="(max-width: 767px) 32px, 48px"
+          />
+        </div>
+        {isSelected && (
+          <div
+            className={`border-yellow pc:border-[4px] absolute top-0 right-0 bottom-0 left-0 rounded-[8px] border-[3px]`}
+          ></div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface EmotionFilterProps {
+  selectedEmotion: EmotionKey | null;
+  setSelectedEmotion: React.Dispatch<React.SetStateAction<EmotionKey | null>>;
+}
+
+export default function EmotionFilter({ selectedEmotion, setSelectedEmotion }: EmotionFilterProps) {
+  const OnClickEmotion = (key: EmotionKey) => {
+    if (selectedEmotion === key) {
+      setSelectedEmotion(null);
+      return;
+    }
+    setSelectedEmotion(key);
+  };
+
+  return (
+    <div
+      className="pc:gap-[16px] absolute top-[36px] flex justify-center gap-[8px] rounded-[16px] bg-blue-100 p-[16px]"
+      style={{ boxShadow: '0px 3px 16px rgba(0, 0, 0, 0.1)' }}
+    >
+      {Object.keys(EmotionData).map((key) => (
+        <Emotion
+          key={key}
+          emotion={key as EmotionKey}
+          isSelected={selectedEmotion === key}
+          onClick={() => OnClickEmotion(key as EmotionKey)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/mypage/_components/MyCalender/EmotionFilter.tsx
+++ b/src/app/mypage/_components/MyCalender/EmotionFilter.tsx
@@ -27,7 +27,7 @@ function Emotion({
   return (
     <div className="flex cursor-pointer flex-col items-center gap-[8px]" onClick={() => onClick(emotion)}>
       <div
-        className={`tablet:h-[64px] tablet:w-[64px] pc:w-[96px] pc:h-[96px] flex h-[48px] w-[48px] items-center justify-center rounded-[8px] ${isSelected ? `relative` : `bg-[#AFBACD]/15`}`}
+        className={`tablet:h-[56px] tablet:w-[56px] pc:w-[96px] pc:h-[96px] flex h-[48px] w-[48px] items-center justify-center rounded-[8px] ${isSelected ? `relative` : `bg-[#AFBACD]/15`}`}
       >
         <div className="pc:h-[48px] pc:w-[48px] relative h-[32px] w-[32px] object-contain">
           <Image
@@ -64,7 +64,7 @@ export default function EmotionFilter({ selectedEmotion, setSelectedEmotion }: E
 
   return (
     <div
-      className="pc:gap-[16px] absolute top-[36px] flex justify-center gap-[8px] rounded-[16px] bg-blue-100 p-[16px]"
+      className="pc:gap-[16px] absolute top-[36px] left-1/2 flex -translate-x-1/2 justify-center gap-[8px] rounded-[16px] bg-blue-100 p-[16px]"
       style={{ boxShadow: '0px 3px 16px rgba(0, 0, 0, 0.1)' }}
     >
       {Object.keys(EmotionData).map((key) => (

--- a/src/app/mypage/_components/MyCalender/EmotionFilter.tsx
+++ b/src/app/mypage/_components/MyCalender/EmotionFilter.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 
-const EmotionData = {
+export const EmotionData = {
   MOVED: {
     image: '/assets/images/heartFace.png',
     name: '감동',

--- a/src/app/mypage/_components/MyCalender/MyCalender.tsx
+++ b/src/app/mypage/_components/MyCalender/MyCalender.tsx
@@ -1,19 +1,27 @@
+'use client';
+
 import { EmotionLog } from '@/types/Emotionlog';
 import CustomCalender from './CustomCalender';
+import { useEffect, useState } from 'react';
+import { GetMonthEmotion } from '@/lib/Emotionlog';
+import moment from 'moment';
 
-export default async function MyCalender() {
-  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/emotionLogs/monthly?userId=1349&year=2025&month=3`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
+export default function MyCalender() {
+  const [data, setData] = useState<EmotionLog[]>();
+  const [displayMonth, setDisplayMonth] = useState<Date>(new Date());
 
-  const data: EmotionLog[] = await response.json();
+  const getData = async () => {
+    const response = await GetMonthEmotion(1349, moment(displayMonth).year(), moment(displayMonth).month() + 1);
+    if (!response) return;
 
-  return (
-    <div>
-      <CustomCalender data={data} />
-    </div>
-  );
+    setData(response);
+  };
+
+  useEffect(() => {
+    getData();
+  }, [displayMonth]);
+
+  if (!data) return;
+
+  return <CustomCalender data={data} displayMonth={displayMonth} setDisplayMonth={setDisplayMonth} />;
 }

--- a/src/app/mypage/_components/MyCalender/MyCalender.tsx
+++ b/src/app/mypage/_components/MyCalender/MyCalender.tsx
@@ -1,0 +1,19 @@
+import { EmotionLog } from '@/types/Emotionlog';
+import CustomCalender from './CustomCalender';
+
+export default async function MyCalender() {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/emotionLogs/monthly?userId=1349&year=2025&month=3`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const data: EmotionLog[] = await response.json();
+
+  return (
+    <div>
+      <CustomCalender data={data} />
+    </div>
+  );
+}

--- a/src/app/mypage/_components/MyCalender/custom-calendar.css
+++ b/src/app/mypage/_components/MyCalender/custom-calendar.css
@@ -23,5 +23,22 @@
   display: none;
 }
 
+@media (width >= 767px) {
+  .react-calendar__month-view__weekdays__weekday {
+    width: 54px;
+    height: 54px;
+  }
+}
+
+@media (width >= 1200px) {
+  .react-calendar__month-view__weekdays__weekday {
+    width: 91px;
+    height: 91px;
+  }
+
+  .react-calendar__month-view__weekdays__weekday {
+    font-size:24px;
+  }
+}
 
 

--- a/src/app/mypage/_components/MyCalender/custom-calendar.css
+++ b/src/app/mypage/_components/MyCalender/custom-calendar.css
@@ -1,0 +1,27 @@
+.react-calendar__month-view__weekdays__weekday {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #C4C4C4;
+  border-top:1px solid #ECEFF4;
+  border-bottom:1px solid #ECEFF4;
+  width: 44px;
+  height: 44px;
+}
+
+.react-calendar__month-view__weekdays__weekday abbr {
+  text-decoration: none;
+}
+
+.react-calendar__tile--now {
+  border: 3px solid #E46E80;
+  color: #E46E80;
+  border-radius: 3px;
+}
+
+.react-calendar__navigation {
+  display: none;
+}
+
+
+

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,5 +1,6 @@
 import EmotionPieChart from './_components/EmotionPieChart';
 import EmotionRankList from './_components/EmotionRankList';
+import MyCalender from './_components/MyCalender/MyCalender';
 import MyTabMenu from './_components/MyTabMenu';
 import TodayEmotion from '@/components/TodayEmotion';
 import MyUserProfile from './_components/MyUserProfile';
@@ -9,7 +10,17 @@ export default function MyPage() {
     <main>
       <div className="pc:mt-[120px] shadow-[0px 0px 36px 0px rgba(0, 0, 0, 0.05)] mt-[64px] rounded-3xl bg-white">
         <div className="relative top-[-53px] m-auto max-w-[680px] px-[24px]">
+<<<<<<< HEAD
           <MyUserProfile />
+=======
+          {/* ✅ 여기에 프로필 컴포넌트과 오늘의 감정 컴포넌트를 구현해주세요. */}
+          {/* ✅ <section> 코드는 예시 입니다. 지우고 작업해주세요:-) */}
+          <section className="flex flex-col items-center">
+            <div className="mb-[16px] h-[120px] w-[120px] rounded-full bg-amber-300"></div>
+            <span>프로필</span>
+          </section>
+          <MyCalender />
+>>>>>>> caca7fa (Chore: 중복 코드 제거)
         </div>
         <TodayEmotion emotionType="mypage" />
         <div className="pc:pb-[82px] tablet:pb-[56px] pc:gap-[48px] m-auto flex h-full w-full max-w-[680px] flex-col justify-center gap-[16px] px-[24px] pt-[58px] pb-[40px]">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -10,20 +10,11 @@ export default function MyPage() {
     <main>
       <div className="pc:mt-[120px] shadow-[0px 0px 36px 0px rgba(0, 0, 0, 0.05)] mt-[64px] rounded-3xl bg-white">
         <div className="relative top-[-53px] m-auto max-w-[680px] px-[24px]">
-<<<<<<< HEAD
           <MyUserProfile />
-=======
-          {/* ✅ 여기에 프로필 컴포넌트과 오늘의 감정 컴포넌트를 구현해주세요. */}
-          {/* ✅ <section> 코드는 예시 입니다. 지우고 작업해주세요:-) */}
-          <section className="flex flex-col items-center">
-            <div className="mb-[16px] h-[120px] w-[120px] rounded-full bg-amber-300"></div>
-            <span>프로필</span>
-          </section>
           <MyCalender />
->>>>>>> caca7fa (Chore: 중복 코드 제거)
         </div>
         <TodayEmotion emotionType="mypage" />
-        <div className="pc:pb-[82px] tablet:pb-[56px] pc:gap-[48px] m-auto flex h-full w-full max-w-[680px] flex-col justify-center gap-[16px] px-[24px] pt-[58px] pb-[40px]">
+        <div className="pc:pb-[82px] tablet:pb-[56px] pc:gap-[48px] m-auto flex h-full w-full max-w-[680px] flex-col justify-center gap-[16px] px-[24px] pb-[40px] pt-[58px]">
           <h1 className="pc:text-pre-2xl text-pre-lg font-weight-semibold">감정 차트</h1>
           <div className="border-line-100 pc:h-[264px] flex h-full w-full items-center justify-between rounded-lg border p-[30px]">
             <EmotionPieChart />
@@ -31,7 +22,7 @@ export default function MyPage() {
           </div>
         </div>
       </div>
-      <div className="pc:pt-[103px] m-auto max-w-[680px] px-[24px] pt-[56px] pb-[114px]">
+      <div className="pc:pt-[103px] m-auto max-w-[680px] px-[24px] pb-[114px] pt-[56px]">
         <MyTabMenu />
       </div>
     </main>

--- a/src/app/sample/_components/Gyeong.tsx
+++ b/src/app/sample/_components/Gyeong.tsx
@@ -1,3 +1,4 @@
+import MyCalender from '@/app/mypage/_components/MyCalender/MyCalender';
 import ClientButton from '@/components/Button/ClientButton';
 import ServerButton from '@/components/Button/ServerButton';
 import TodayEmotion from '@/components/TodayEmotion';
@@ -50,6 +51,7 @@ export default function Gyeong() {
           <ClientButton isValid={false} className="w-full">
             클라이언트
           </ClientButton>
+          <MyCalender />
         </div>
       </div>
     </>

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+// 'use client';
 
 import Gyeong from './_components/Gyeong';
 import Jin from './_components/Jin';

--- a/src/types/Emotionlog.ts
+++ b/src/types/Emotionlog.ts
@@ -1,5 +1,5 @@
 // 감정 타입
-export type EmotionType = 'MOVED' | 'HAPPY' | 'SAD' | 'ANGRY' | 'CALM';
+export type EmotionType = 'MOVED' | 'HAPPY' | 'SAD' | 'ANGRY' | 'WORRIED';
 
 // 감정 로그 기본 타입
 // 1. 오늘의 감정 기록 생성 (POST /{teamId}/emotionLogs/today)


### PR DESCRIPTION
## #️⃣ 이슈

- close #94 

## 📝 작업 내용

마이페이지에 들어가는 캘린더 기능을 구현했습니다!
기능구현을 우선으로 하다보니 코드가 길어지고 정리해야할 부분이 있는데, 코드 리팩토링 기간에 수정해보겠습니다...!
감정 로그를 가져오는 유저 아이디는 임의로 넣어둔 상태이고, 필터링도 가능합니다.

날짜 format을 위한 moment 라이브러리와
react-calendar 캘린더 라이브러리를 활용했습니다.
react-calendar 캘린더를 커스텀하는 과정에서 지정된 class에 스타일을 넣어줘야해서 어쩔수없이 css파일을 따로 하나 만들어뒀습니다.

## 📸 결과물

![image](https://github.com/user-attachments/assets/53a4d44b-cc7c-4ac2-9b8d-598497bbd66d)


## 👩‍💻 공유 포인트 및 논의 사항

감정log를 가져오는 과정에서 선택한 달의 데이터만 가져올 수 있는 듯 한데...
그렇게 되면 파란색으로 표시한 부분의 데이터는 비게 됩니다.

![image](https://github.com/user-attachments/assets/0115b3ab-c78e-440f-9ae7-c1cd5e4ddb19)

이 경우 어떤식으로 해야할지 고민입니다.
api요청을 이전달 + 이번달 + 다음달 이러한 방식으로 3번 해야할지....
아니면 이번달만 보여주도록 해야할지....
이건 한번 다 같이 이야기 해봤으면 좋겠습니다! 
