### PR TITLE
Fix(#123): 에피그램 폼 제출시 페이지 이동

### DIFF
--- a/src/components/EpigramForm.tsx
+++ b/src/components/EpigramForm.tsx
@@ -4,6 +4,7 @@ import { TagsInputWithList } from '@/components/TagsInputWithList';
 import { PatchEpigram, PostEpigram } from '@/lib/Epigram';
 import { EpigramTag } from '@/types/Epigram';
 import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import { ChangeEvent, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -46,6 +47,7 @@ export default function EpigramForm({
   });
 
   const { data: session, status } = useSession();
+  const router = useRouter();
   const token = status === 'authenticated' ? session?.user.accessToken : null;
 
   const selectedOption = watch('authorSelected');
@@ -71,7 +73,7 @@ export default function EpigramForm({
     const allValues = watch();
     const response = await PostEpigram(allValues, token);
     if (!response) return;
-    alert('폼 제출 완료');
+    router.push(`/feed/${response.id}`);
   };
 
   const SubmitPatchForm = async () => {
@@ -79,7 +81,7 @@ export default function EpigramForm({
     const allValues = watch();
     const response = await PatchEpigram(allValues, initialValue.id, token);
     if (!response) return;
-    alert('폼 수정 완료');
+    router.push(`/feed/${response.id}`);
   };
 
   const SelectForm = submitType === '작성하기' ? SubmitPostForm : SubmitPatchForm;

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { EpigramTag } from '@/types/Epigram';
+import { z } from 'zod';
 
 interface TagsInputProps {
   onAddTag: (tag: EpigramTag) => void; // 부모로부터 태그 추가 함수 받기
@@ -11,9 +12,15 @@ interface TagsInputProps {
 export function TagsInput({ onAddTag, tags }: TagsInputProps) {
   const [inputValue, setInputValue] = useState<string>('');
 
+  const tagSchema = z
+    .string()
+    .max(10, '최대 10자까지 입력할 수 있습니다.')
+    .transform((value) => value.replace(/[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]/g, ''));
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value.length <= 10) {
-      setInputValue(e.target.value);
+    const result = tagSchema.safeParse(e.target.value);
+    if (result.success) {
+      setInputValue(result.data);
     }
   };
 

--- a/src/lib/Epigram.ts
+++ b/src/lib/Epigram.ts
@@ -32,7 +32,7 @@ export async function PostEpigram(epigrams: AddEpigram, token: string) {
     if (!response.ok || response === null) {
       throw new Error('서버 오류가 발생하였습니다.');
     }
-    const data = response.json();
+    const data = await response.json();
     return data;
   } catch (error: unknown) {
     if (error instanceof Error) {
@@ -71,7 +71,7 @@ export async function PatchEpigram(epigrams: AddEpigram, id: number, token: stri
     if (!response.ok || response === null) {
       throw new Error('서버 오류가 발생하였습니다.');
     }
-    const data = response.json();
+    const data = await response.json();
     return data;
   } catch (error: unknown) {
     if (error instanceof Error) {


### PR DESCRIPTION
## #️⃣ 이슈

- close #123 

## 📝 작업 내용

에피그램 포스팅 혹은 수정시, 상세페이지 경로로 이동하도록 설정해뒀습니다!
태그 input의 경우, 기존에 띄어쓰기와 특수문자 입력이 가능하던것을 불가능하게 막아뒀습니다.

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
