### PR TITLE
Fix(#121_ 로그인과 회원가입 부분 수정

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -40,7 +40,7 @@ export default function LoginPage() {
     }); // 응답 로그 확인
 
     if (res?.error) {
-      setError(res.error); // NextAuth에서 받은 에러 메시지를 그대로 사용
+      setError('이메일 또는 비밀번호가 다릅니다.'); // NextAuth에서 받은 에러 메시지를 그대로 사용
       return;
     }
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -169,7 +169,7 @@ export default function Page() {
           가입하기
         </button>
         {error && (
-          <p className="text-state-error text-pre-xs font-regular tablet:text-pre-md pc:text-pre-lg tablet:bottom-[-26px] pc:bottom-[-28px] absolute bottom-[-22px]">
+          <p className="text-state-error text-pre-xs font-regular tablet:text-pre-md pc:text-pre-lg tablet:bottom-[-26px] pc:bottom-[-28px] bottom-[-22px]">
             {error}
           </p>
         )}

--- a/src/app/oauth/google-callback/page.tsx
+++ b/src/app/oauth/google-callback/page.tsx
@@ -58,7 +58,7 @@ export default function GoogleOAuthCallback() {
         const data = await response.json();
         console.log('Swagger API 응답:', data);
         // 성공 시, 원하는 페이지로 리디렉션
-        router.push('/epigrams');
+        router.push('/main');
       } catch (error: unknown) {
         if (error instanceof Error) {
           console.error('Swagger API 호출 에러:', error.message);

--- a/src/app/sample/_components/Su.tsx
+++ b/src/app/sample/_components/Su.tsx
@@ -1,4 +1,3 @@
-
 export default function Su() {
   return (
     <>

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -95,7 +95,7 @@ export default function MainHeader() {
                 </div>
                 <div
                   className="text-pre-md font-weight-regular cursor-pointer p-2 hover:bg-gray-200"
-                  onClick={() => signOut()} //로그아웃
+                  onClick={() => signOut({ callbackUrl: '/' })} //로그아웃
                 >
                   로그아웃
                 </div>

--- a/src/lib/next-auth/auth.ts
+++ b/src/lib/next-auth/auth.ts
@@ -119,6 +119,24 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
         token.accessToken = user.accessToken;
         token.refreshToken = user.refreshToken;
       }
+      const isAccessTokenExpired = token.accessToken && token.exp && Date.now() >= token.exp * 1000;
+      if (isAccessTokenExpired) {
+        try {
+          const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/refresh-token`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ refreshToken: token.refreshToken }),
+          });
+
+          if (!res.ok) throw new Error('토큰 갱신 실패');
+
+          const data = await res.json();
+          token.accessToken = data.accessToken;
+        } catch (error) {
+          console.error('토큰 갱신 실패:', error);
+          return null;
+        }
+      }
       return token;
     },
     async session({ session, token }) {

--- a/src/lib/next-auth/auth.ts
+++ b/src/lib/next-auth/auth.ts
@@ -134,7 +134,7 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       return session;
     },
     async redirect() {
-      return 'http://localhost:3000/epigrams';
+      return 'http://localhost:3000/main';
     },
   },
 });

--- a/src/lib/next-auth/auth_provider.tsx
+++ b/src/lib/next-auth/auth_provider.tsx
@@ -1,15 +1,8 @@
 'use client';
 
-import { SessionProvider, getSession } from 'next-auth/react';
-import { useEffect, useState, type ReactNode } from 'react';
-import { Session } from 'next-auth';
+import { SessionProvider } from 'next-auth/react';
+import type { ReactNode } from 'react';
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [session, setSession] = useState<Session | null>(null);
-
-  useEffect(() => {
-    getSession().then(setSession); // 세션 정보를 직접 가져와 상태에 저장
-  }, []);
-
-  return <SessionProvider session={session}>{children}</SessionProvider>;
+  return <SessionProvider>{children}</SessionProvider>;
 }

--- a/src/lib/next-auth/auth_provider.tsx
+++ b/src/lib/next-auth/auth_provider.tsx
@@ -1,8 +1,15 @@
 'use client';
 
-import { SessionProvider } from 'next-auth/react';
-import type { ReactNode } from 'react';
+import { SessionProvider, getSession } from 'next-auth/react';
+import { useEffect, useState, type ReactNode } from 'react';
+import { Session } from 'next-auth';
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    getSession().then(setSession); // 세션 정보를 직접 가져와 상태에 저장
+  }, []);
+
+  return <SessionProvider session={session}>{children}</SessionProvider>;
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #121 

## 📝 작업 내용
- 로그인과 회원가입 실패시 오류 메시지 수정
- 로그아웃시 로그인 페이지로 이동
- 토큰 유효기간 만료시 자동발급 설정
## 📸 결과물
![스크린샷 2025-04-01 오후 4 14 58](https://github.com/user-attachments/assets/ca8f5272-f93b-40d0-a35b-e8a3295c3f73)
![스크린샷 2025-04-01 오후 4 14 23](https://github.com/user-attachments/assets/d75474e7-ee04-47d4-b632-667ed9afca53)


## 👩‍💻 공유 포인트 및 논의 사항
현재 세션에 토큰 정보 보이는것을 수정하는것 빼곤 다했습니다. 그부분이 오래 걸릴거 같아서 우선 다른 바로바로 수정 가능한 부분 부터 하겠습니다.
토큰을 혹시 다시 못 받아올 시 말씀해주시면 감사하겠습니다.(작업하다 만료되서 다시 해보니 작동안되는걸 확인했습니다 수정해놓겠습니다.)