### PR TITLE
Fix(#133): 댓글 더보기 스냅샷 적용

### DIFF
--- a/src/app/feed/[id]/_component/EpigramCommentList.tsx
+++ b/src/app/feed/[id]/_component/EpigramCommentList.tsx
@@ -8,23 +8,27 @@ interface EpigramCommentListProps {
   epigramId: number;
   comments: Comment[];
   setComments: React.Dispatch<React.SetStateAction<Comment[]>>;
+  setTotalCount: React.Dispatch<React.SetStateAction<number>>;
 }
 
-export default function EpigramCommentList({ epigramId, comments, setComments }: EpigramCommentListProps) {
+export default function EpigramCommentList({ comments, setComments, setTotalCount }: EpigramCommentListProps) {
   const { data: session, status } = useSession();
 
   const token = status === 'authenticated' ? session?.user.accessToken : undefined;
-
-  const filteredComments = comments.filter((comment) => comment.epigramId === epigramId);
+  const writerId = session?.user.id ? Number(session.user.id) : undefined;
 
   return (
     <div>
-      {filteredComments.map((comment) => (
+      {comments.map((comment) => (
         <CommentItem
           key={comment.id}
           comment={comment}
           token={token}
-          onDelete={(id) => setComments((prev) => prev.filter((c) => c.id !== id))}
+          writerId={writerId}
+          onDelete={(id) => {
+            setComments((prev) => prev.filter((c) => c.id !== id));
+            setTotalCount((prev) => prev - 1);
+          }}
           onSave={(updated) => setComments((prev) => prev.map((c) => (c.id === updated.id ? updated : c)))}
         />
       ))}

--- a/src/app/feed/[id]/_component/EpigramCommentSection.tsx
+++ b/src/app/feed/[id]/_component/EpigramCommentSection.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useState } from 'react';
 import EpigramCommentList from './EpigramCommentList';
-import { createComment, getComments } from '@/lib/Comment';
+import { createComment } from '@/lib/Comment';
 import type { Comment } from '@/types/Comment';
 import CommentCount from './CommentCount';
 import CommentInput from './CommentInput';
 import { useSession } from 'next-auth/react';
 // @ts-expect-error : 타입스크립트가 notFound를 오류로 인식합니다. 작동은 잘 됩니다.
 import { useParams } from 'next/navigation';
+import { getEpigramComments } from '@/lib/Epigram';
 
 export default function EpigramCommentSection() {
   const { data: session, status } = useSession();
@@ -16,18 +17,20 @@ export default function EpigramCommentSection() {
   const epigramId = Number(id);
 
   const [comments, setComments] = useState<Comment[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
 
-  const token = status === 'authenticated' ? session?.user.accessToken : null;
+  const token = session?.user.accessToken;
   const userImage = session?.user?.image;
 
   useEffect(() => {
-    if (!token || !epigramId) return;
+    if (!token || !epigramId || Number.isNaN(epigramId)) return;
 
     const fetch = async () => {
       try {
-        const res = await getComments(token, 50, 0, epigramId.toString());
+        const res = await getEpigramComments(token, epigramId, 50);
 
         setComments(res.list);
+        setTotalCount(res.totalCount);
       } catch (err) {
         console.error('댓글 불러오기 실패', err);
       }
@@ -37,7 +40,7 @@ export default function EpigramCommentSection() {
   }, [epigramId, token]);
 
   const handleCreate = async (content: string, isPrivate: boolean) => {
-    if (!token || !epigramId) {
+    if (!token) {
       alert('로그인이 필요합니다.');
       return;
     }
@@ -46,6 +49,7 @@ export default function EpigramCommentSection() {
       const response = await createComment(token, epigramId, content, isPrivate);
 
       setComments((prev) => [response, ...prev]); // 새 댓글 맨 위에 추가
+      setTotalCount((prev) => prev + 1); // 댓글수 실시간 증가
     } catch (err) {
       console.error('댓글 작성 실패', err);
       alert('댓글 작성 중 오류가 발생했습니다.');
@@ -62,11 +66,16 @@ export default function EpigramCommentSection() {
 
   return (
     <div className="rounded-md bg-[#F5F7FA] px-4 py-6">
-      <CommentCount count={comments.length} />
+      <CommentCount count={totalCount} />
 
       <CommentInput userImage={userImage} onSubmit={handleCreate} />
 
-      <EpigramCommentList epigramId={epigramId} comments={comments} setComments={setComments} />
+      <EpigramCommentList
+        epigramId={epigramId}
+        comments={comments}
+        setComments={setComments}
+        setTotalCount={setTotalCount}
+      />
     </div>
   );
 }

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -22,7 +22,7 @@ export default function Page() {
           <div className="pc:mb-[140px] mb-[56px]">
             <LatestEpigrams />
           </div>
-          <div>
+          <div className="tablet:pb-[270px] pc:pb-[119px] pb-[114px]">
             <LatestCommentSection />
           </div>
         </div>

--- a/src/app/mypage/_components/MyCommentList.tsx
+++ b/src/app/mypage/_components/MyCommentList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { CommentItem } from '@/components/Comment/CommentItem';
 import { getUserComments } from '@/lib/User';
 import { useSession } from 'next-auth/react';

--- a/src/app/mypage/_components/MyComments.tsx
+++ b/src/app/mypage/_components/MyComments.tsx
@@ -1,9 +1,5 @@
 import MyCommentList from './MyCommentList';
 
 export default function MyComments() {
-  return (
-    <div>
-      <MyCommentList />
-    </div>
-  );
+  return <MyCommentList />;
 }

--- a/src/components/Comment/CommentEmpty.tsx
+++ b/src/components/Comment/CommentEmpty.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+interface CommentEmptyProps {
+  showButton?: boolean;
+}
+
+export default function CommentEmpty({ showButton = true }: CommentEmptyProps) {
+  const router = useRouter();
+
+  return (
+    <div className="flex w-full flex-col items-center justify-center py-20 text-center">
+      <Image
+        src="assets/images/empty.svg"
+        alt="댓글 없음"
+        width={80}
+        height={80}
+        className="pc:w-[144px] pc:h-[144px] mb-6 h-[96px] w-[96px] opacity-60"
+      />
+      <p className="pc:text-[20px] pc:leading-[32px] text-black-600 text-[14px] leading-[24px] font-normal">
+        아직 작성한 댓글이 없어요!
+      </p>
+      <p className="pc:text-[20px] pc:leading-[32px] text-black-600 tablet:mb-[40px] pc:mb-[48px] mb-[32px] text-[14px] leading-[24px] font-normal">
+        댓글을 달고 다른 사람들과 교류해보세요.
+      </p>
+      {showButton && (
+        <button
+          onClick={() => router.push('/feed')}
+          className="pc:text-pre-xl pc:px-[40px] text-pre-md bg-bg-100 flex cursor-pointer gap-[4px] rounded-full border border-blue-500 px-[18px] py-[11.5px] font-medium text-blue-500 transition hover:bg-blue-900 hover:text-white"
+        >
+          에피그램 둘러보기
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/Comment/CommentList.tsx
+++ b/src/components/Comment/CommentList.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect } from 'react';
 import { CommentItem } from './CommentItem';
 import { useSession } from 'next-auth/react';
-import { usePathname } from 'next/navigation';
 import { useCommentStore } from '@/stores/pageStores';
 import { getComments } from '@/lib/Comment';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
@@ -12,7 +11,6 @@ import { Comment } from '@/types/Comment';
 
 export default function CommentList() {
   const { data: session, status } = useSession();
-  const pathname = usePathname();
   const token = status === 'authenticated' ? session?.user.accessToken : null;
 
   const writerId = session?.user.id ? Number(session.user.id) : undefined;

--- a/src/components/Comment/CommentList.tsx
+++ b/src/components/Comment/CommentList.tsx
@@ -1,57 +1,70 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import { getComments } from '@/lib/Comment';
-import type { Comment } from '@/types/Comment';
+import React, { useEffect } from 'react';
 import { CommentItem } from './CommentItem';
 import { useSession } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
+import { useCommentStore } from '@/stores/pageStores';
+import { getComments } from '@/lib/Comment';
+import { usePaginatedList } from '@/hooks/usePaginatedList';
+import Image from 'next/image';
+import { Comment } from '@/types/Comment';
 
 export default function CommentList() {
   const { data: session, status } = useSession();
   const pathname = usePathname();
-
-  const [comments, setComments] = useState<Comment[]>([]);
-
   const token = status === 'authenticated' ? session?.user.accessToken : null;
 
-  const writerId = pathname.startsWith('/mypage') && session?.user.id ? Number(session.user.id) : undefined;
+  const writerId = session?.user.id ? Number(session.user.id) : undefined;
+
+  const { items: comments, hasMore } = useCommentStore();
+
+  const fetchComments = async (cursor?: number) => {
+    if (!token) return { list: [], totalCount: 0 };
+
+    const realCursor = cursor ?? 0;
+    return await getComments(token, 4, realCursor);
+  };
+
+  const { loadMore, loading } = usePaginatedList<Comment>({
+    store: useCommentStore.getState(),
+    fetchFn: fetchComments,
+  });
 
   useEffect(() => {
-    const fetchComments = async () => {
-      if (!token) return;
+    if (status === 'authenticated' && token && comments.length === 0) {
+      loadMore();
+    }
+  }, [status, token, comments.length]);
 
-      try {
-        const response = await getComments(token, 4, 0);
-        setComments(response.list);
-      } catch (error) {
-        console.error('댓글 불러오기 실패:', error);
-      }
-    };
-
-    fetchComments();
-  }, [token]); //세션이 바뀌면 댓글 다시 불러옴
-
-  if (status === 'loading') {
-    return <div>로딩 중...</div>;
-  }
-
-  if (!session) {
-    return <div>로그인이 필요합니다.</div>;
-  }
+  if (status === 'loading') return <div>로딩 중...</div>;
+  if (!session) return <div>로그인이 필요합니다.</div>;
 
   return (
-    <div className="w-full">
+    <div className="w-full space-y-4">
       {comments.map((comment) => (
         <CommentItem
           key={comment.id}
           comment={comment}
           token={token!}
-          onDelete={(id) => setComments((prev) => prev.filter((c) => c.id !== id))}
-          onSave={(updated) => setComments((prev) => prev.map((c) => (c.id === updated.id ? updated : c)))}
+          onDelete={() => {}}
+          onSave={() => {}}
           writerId={writerId}
         />
       ))}
+
+      {hasMore && (
+        <div className="mt-8 flex justify-center">
+          <button
+            onClick={loadMore}
+            className="pc:text-pre-xl pc:px-[40px] text-pre-md bg-bg-100 flex cursor-pointer gap-[4px] rounded-full border border-blue-500 px-[18px] py-[11.5px] font-medium text-blue-500 transition hover:bg-blue-900 hover:text-white"
+            disabled={loading}
+          >
+            <Image src="/assets/icons/plus.svg" width={24} height={24} alt="더보기" />
+            최신 댓글 더보기
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/UK/InfiniteList.tsx
+++ b/src/components/UK/InfiniteList.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client';
 
-import React, { useEffect, useState, JSX } from "react";
+import React, { useEffect, useState, JSX } from 'react';
 
 interface FetchResult<T> {
   list: T[];
@@ -20,8 +20,8 @@ export default function InfiniteList<T extends { id: string | number }>({
   fetchItems,
   renderItem,
   limit = 5,
-  buttonText = "+ 더보기",
-  storageKey = "infinite_list",
+  buttonText = '+ 더보기',
+  storageKey = 'infinite_list',
 }: InfiniteListProps<T>) {
   const [items, setItems] = useState<T[]>([]);
   const [cursor, setCursor] = useState<number | null>(null);
@@ -30,14 +30,14 @@ export default function InfiniteList<T extends { id: string | number }>({
   const [shouldAutoLoad, setShouldAutoLoad] = useState(false);
 
   const isRefresh = (() => {
-    if (typeof window === "undefined") return false;
-    const entries = window.performance.getEntriesByType("navigation");
+    if (typeof window === 'undefined') return false;
+    const entries = window.performance.getEntriesByType('navigation');
     const nav = entries.length > 0 ? (entries[0] as PerformanceNavigationTiming) : null;
-    return nav?.type === "reload";
+    return nav?.type === 'reload';
   })();
 
   useEffect(() => {
-    if (typeof window !== "undefined" && isRefresh) {
+    if (typeof window !== 'undefined' && isRefresh) {
       localStorage.removeItem(`${storageKey}_items`);
       localStorage.removeItem(`${storageKey}_cursor`);
       localStorage.removeItem(`${storageKey}_hasMore`);
@@ -63,7 +63,7 @@ export default function InfiniteList<T extends { id: string | number }>({
       setShouldAutoLoad(shouldLoad);
     };
 
-    if (typeof window !== "undefined") {
+    if (typeof window !== 'undefined') {
       restore();
     }
   }, []);
@@ -75,7 +75,7 @@ export default function InfiniteList<T extends { id: string | number }>({
   }, [shouldAutoLoad]);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
+    if (typeof window !== 'undefined') {
       localStorage.setItem(`${storageKey}_items`, JSON.stringify(items));
       localStorage.setItem(`${storageKey}_cursor`, JSON.stringify(cursor));
       localStorage.setItem(`${storageKey}_hasMore`, JSON.stringify(hasMore));
@@ -99,8 +99,8 @@ export default function InfiniteList<T extends { id: string | number }>({
       window.history.replaceState({ scrollPosition }, '', window.location.pathname);
     };
 
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, []);
 
   const loadMore = async () => {
@@ -114,15 +114,13 @@ export default function InfiniteList<T extends { id: string | number }>({
         return;
       }
 
-      const newItems = data.list.filter(
-        (item) => !items.some((existing) => existing.id === item.id)
-      );
+      const newItems = data.list.filter((item) => !items.some((existing) => existing.id === item.id));
 
       setItems((prev) => [...prev, ...newItems]);
       setCursor(data.nextCursor);
       setHasMore(data.hasMore);
     } catch (error) {
-      console.error("데이터 로딩 실패:", error);
+      console.error('데이터 로딩 실패:', error);
       setHasMore(false);
     } finally {
       setLoading(false);
@@ -135,17 +133,17 @@ export default function InfiniteList<T extends { id: string | number }>({
         {items.map((item, index) =>
           React.cloneElement(renderItem(item, index), {
             key: `${item.id}_${index}`,
-          })
+          }),
         )}
       </ul>
 
-      {loading && <p className="text-center text-gray-500 mt-4">로딩 중...</p>}
+      {loading && <p className="mt-4 text-center text-gray-500">로딩 중...</p>}
 
       {!loading && hasMore && (
-        <div className="text-center mt-6">
+        <div className="mt-6 text-center">
           <button
             onClick={loadMore}
-            className="px-6 py-3 bg-blue-100 rounded-full text-blue-600 border border-blue-300 hover:bg-blue-200 transition"
+            className="rounded-full border border-blue-300 bg-blue-100 px-6 py-3 text-blue-600 transition hover:bg-blue-200"
           >
             {buttonText}
           </button>

--- a/src/lib/Comment.ts
+++ b/src/lib/Comment.ts
@@ -4,6 +4,12 @@ import { CommentList } from '@/types/Comment';
 
 // 댓글 작성
 export async function createComment(token: string, epigramId: number, content: string, isPrivate: boolean) {
+  console.log('[createComment] 보내는 body:', {
+    epigramId,
+    content,
+    isPrivate,
+  });
+
   const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/comments`, {
     method: 'POST',
     headers: {
@@ -13,7 +19,11 @@ export async function createComment(token: string, epigramId: number, content: s
     body: JSON.stringify({ epigramId, isPrivate, content }),
   });
 
-  if (!response.ok) throw new Error('댓글 작성 실패');
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('[createComment] 서버 응답 실패:', errorText); // 응답 본문 로그!
+    throw new Error('댓글 작성 실패');
+  }
   return await response.json();
 }
 

--- a/src/lib/Epigram.ts
+++ b/src/lib/Epigram.ts
@@ -2,6 +2,7 @@ import { Epigram } from '@/types/Epigram';
 import { AddEpigram } from '@/components/EpigramForm';
 // @ts-expect-error : 타입스크립트가 notFound를 오류로 인식합니다. 작동은 잘 됩니다.
 import { notFound } from 'next/navigation';
+import { CommentList } from '@/types/Comment';
 
 // 에피그램 post
 export async function PostEpigram(epigrams: AddEpigram, token: string) {
@@ -173,5 +174,33 @@ export async function GetEpigram(id: number, token: string) {
     return null;
   }
   const data = await response.json();
+  return data;
+}
+
+//에피그램 댓글목록 조회
+export async function getEpigramComments(
+  token: string,
+  epigramId: number,
+  limit: number,
+  cursor?: number,
+): Promise<CommentList> {
+  let url = `${process.env.NEXT_PUBLIC_API_URL}/epigrams/${epigramId}/comments?limit=${limit}`;
+  if (cursor !== undefined) {
+    url += `&cursor=${cursor}`;
+  }
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('에피그램 댓글 목록 조회 실패');
+  }
+
+  const data: CommentList = await response.json();
   return data;
 }

--- a/src/stores/pageStores.ts
+++ b/src/stores/pageStores.ts
@@ -4,3 +4,4 @@ import { createPaginatedListStore } from './paginatedListStore';
 
 export const useFeedStore = createPaginatedListStore<Epigram>();
 export const useCommentStore = createPaginatedListStore<Comment>();
+export const useMyCommentStore = createPaginatedListStore<Comment>();


### PR DESCRIPTION
## #️⃣ 이슈

- close #133 

## 📝 작업 내용

1. 댓글 더보기 스냅샷 적용
2. 로그인 유저 댓글  수정/삭제 버튼 활성
(기존 토큰 하드코딩식에서 세션기반인증처리후 본인 댓글은 본인에게만 수정/삭제 버튼 활성화 되도록 구현)

## 📸 결과물
1) 댓글 더보기 스냅샷 적용

https://github.com/user-attachments/assets/a87ce0b3-d467-4e1c-9321-efd1bba7873c


2) 로그인 유저 댓글  수정/삭제 버튼 활성

https://github.com/user-attachments/assets/459f5c92-e937-47c6-b33b-f2333abdbfc9



## 👩‍💻 공유 포인트 및 논의 사항
리뷰러가 주섭님이라 딱 의논할 내용 전달 드리기 적절한거 같은데,
현재 저가 담당하는 모든 댓글부분이 로그인후(토큰발급후) 일정시간이 지나면 토큰 만료가 되어서
그런지 그이후는 댓글 리스트 조회나 본인의 댓글수정/삭제를 이용할 수 가 없던데,, 이거 auth를 수정을 해야하나요? 아니면 저의 코드 로직을 바꿔야 하는건지...
