### PR TITLE
Fix: 오늘의 에피그램 없을 때 나타나는 이미지 및 css 수정 작업

### DIFF
--- a/src/app/main/_conponents/todayEpigrams.tsx
+++ b/src/app/main/_conponents/todayEpigrams.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { GetTodayEpigram } from '@/lib/Epigram';
 import { EpigramDetail } from '@/types/Epigram';
 import FeedCard from '@/components/FeedCard';
+import EmptyState from '@/components/EmptyState';
 
 export default function TodayEpirams() {
   const [todayEpigram, setTodayEpigram] = useState<EpigramDetail | null>(null);
@@ -19,13 +20,13 @@ export default function TodayEpirams() {
   }, []);
 
   if (!todayEpigram) {
-    return <div className="text-center">오늘의 에피그램을 불러오는중..</div>;
+    return <EmptyState message={`아직 작성한 에피그램이 없어요!<br/>에피그램을 작성하고 감정을 공유해보세요.`} />;
   }
 
   return (
-    <section className="pc:gap-[40px] mt-[24px] grid h-full w-full gap-[24px]">
+    <section className="pc:gap-[40px] pc:mt-[120px] mt-[24px] grid h-full w-full gap-[24px]">
       <h2 className="text-pre-lg font-weight-semibold txt-color-black-900 pc:text-iro-2xl">오늘의 에피그램</h2>
-      <div className="bg-color-blue-100 tablet:h-[146px] pc:h-[148px] h-[152px] w-full rounded-[16px] border border-white">
+      <div className="bg-color-blue-100 h-full w-full rounded-[16px]">
         <FeedCard data={todayEpigram} />
       </div>
     </section>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -11,13 +11,9 @@ export default function Page() {
           <div className="pc:mb-[140px] mb-[56px]">
             <TodayEpirams />
           </div>
-          <div className="pc:gap-[40px] mb-[56px] grid gap-[24px]">
-            <div className="text-pre-lg pc:text-iro-2xl">
-              <p>오늘의 감정은 어떤가요?</p>
-            </div>
-            <div>
-              <TodayEmotion emotionType="main" />
-            </div>
+          <div className="pc:gap-[40px] pc:mb-[140px] mb-[56px] grid gap-[24px]">
+            <div className="text-pre-lg pc:text-iro-2xl">오늘의 감정은 어떤가요?</div>
+            <TodayEmotion emotionType="main" />
           </div>
           <div className="pc:mb-[140px] mb-[56px]">
             <LatestEpigrams />


### PR DESCRIPTION
## #️⃣ 이슈

- close #143 

## 📝 작업 내용
오늘의 에피그램 없을 때 나타나는 이미지와 검수사항에 있던 반응형에 대해 수정사항을 수정한 수정본입니다.
## 📸 결과물

https://github.com/user-attachments/assets/182495ec-0152-4c24-a5ca-996b127ff404

## 👩‍💻 공유 포인트 및 논의 사항
-현재 오늘의 에피그램이 없을 때 나타나는 이미지를 한솔님께서 만들어 놓으신 에피그램이 없을 때 나타나는 이미지를 저도 사용했는데 통일성있게 하는게 좋을거 같아서 가져다가 썼는데 혹시 다른것으로 만들었으면 좋겠다는 분이나 가져다 쓰지 않았으면 좋겠다 하시는분 계시면 수정하도록 하겠습니다.