### PR TITLE
Fix(#148) : 마이페이지 오늘의 감정 날짜 로직 변경 (오늘 날짜를 보여주도록)

### DIFF
--- a/src/app/mypage/_components/TodayEmotionHeader.tsx
+++ b/src/app/mypage/_components/TodayEmotionHeader.tsx
@@ -1,30 +1,12 @@
-// import { useEffect, useState } from 'react';
-
 export default function TodayEmotionHeader() {
-  // const [headerData, setHeaderData] = useState<{ data: string; emotion: string }>({ data: '', emotion: '' });
-
-  // useEffect(() => {
-  //   const storedData = localStorage.getItem('todayEmotion');
-
-  //   if (storedData) {
-  //     const parsedData = JSON.parse(storedData);
-
-  //     setHeaderData({
-  //       data: parsedData.data,
-  //       emotion: parsedData.emotion,
-  //     });
-  //   } else {
-  //     console.log('No data found in localStorage');
-  //   }
-  // }, []);
-
+  const today = new Date();
+  const formattedDate = `${today.getFullYear()}.${today.getMonth() + 1}.${today.getDate()}`;
+  console.log(formattedDate);
   return (
-    <div className="flex items-center justify-center">
-      <div className="tablet:w-[384px] pc:w-[640px] pc:h-[32px] pc:mb-[48px] mb-[24px] flex h-[26px] w-[312px] justify-between">
+    <div className="flex w-full flex-col items-center justify-center gap-[22px]">
+      <div className="flex w-full items-center justify-between">
         <p className="text-pre-lg font-weight-semibold pc:text-pre-2xl">오늘의 감정</p>
-        <p className="text-pre-lg font-weight-regular pc:text-mon-sm text-blue-400">
-          {/* {headerData?.data || '등록된 날짜가 없습니다.'} */}
-        </p>
+        <p className="text-pre-lg font-weight-regular pc:text-mon-sm text-blue-400">{formattedDate}</p>
       </div>
     </div>
   );

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -18,8 +18,10 @@ export default async function MyPage() {
         <div className="relative top-[-53px] m-auto max-w-[680px] px-[24px]">
           <MyUserProfile />
         </div>
-        <TodayEmotionHeader />
-        <TodayEmotion emotionType="mypage" />
+        <div className="pc:pb-[165px] tablet:pb-[62px] pc:gap-[48px] m-auto flex h-full w-full max-w-[680px] flex-col justify-center gap-[16px] px-[24px] pt-[58px] pb-[58px]">
+          <TodayEmotionHeader />
+          <TodayEmotion emotionType="mypage" />
+        </div>
         <div className="pc:pb-[82px] tablet:pb-[56px] pc:gap-[48px] m-auto flex h-full w-full max-w-[680px] flex-col justify-center gap-[16px] px-[24px] pt-[58px] pb-[40px]">
           <MyCalender writerId={writerId} />
           <h1 className="pc:text-pre-2xl text-pre-lg font-weight-semibold">감정 차트</h1>


### PR DESCRIPTION
## #️⃣ 이슈

- close #148

## 📝 작업 내용
자바스크립트 함수로 오늘의 감정의 날짜에 오늘 날짜를 보여주도록 하였습니다.
layout도 div 태그를 오늘의 감정 컴포넌트를 감싸여 아래 컴포넌트들과 비슷해지도록 수정하였습니다

## 📸 결과물
![image](https://github.com/user-attachments/assets/e5d00a16-c1d3-4c00-9e73-c12fed025848)
![image](https://github.com/user-attachments/assets/7dfd7542-ccbb-4e16-a45d-900d5eff4866)


## 👩‍💻 공유 포인트 및 논의 사항
은경님이 말씀해주신 라이브러리 쓰려다가 라이브러리가 너무 많으면 로딩 속도가 느려질 것 같아서 일단 javascript 내장 함수로 구현하였습니다.
