### PR TITLE
Fix(#131) : 로그인후 feed에 접속 불가 로직, 로그인 후 자동으로 main 페이지로

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,14 +19,15 @@ export const middleware = async (request: NextRequest) => {
   const pathname = request.nextUrl.pathname;
 
   // 로그인 전 접근 가능한 경로 (로그인 전 경로에 대해서만 리디렉션을 처리)
-  const isBeforeLoginRoute = pathname === '/auth/login' || pathname === '/auth/signup';
+  const isBeforeLoginRoute = pathname === '/auth/login' || pathname === '/auth/signup' || pathname === '/';
 
   // 로그인 후 접근 가능한 경로 (로그인 후 경로에 대해서만 리디렉션을 처리)
-  const isAfterLoginRoute = pathname.startsWith('/mypage') || pathname.startsWith('/main');
+  const isAfterLoginRoute =
+    pathname.startsWith('/mypage') || pathname.startsWith('/main') || pathname.startsWith('/feed');
 
   // 로그인 전 경로에 로그인된 상태로 접근 시 홈 페이지로 리디렉션
   if (isBeforeLoginRoute && isAuthenticated) {
-    return NextResponse.redirect(new URL('/', request.nextUrl)); // 홈 페이지로 리디렉션
+    return NextResponse.redirect(new URL('/main', request.nextUrl)); // 홈 페이지로 리디렉션
   }
 
   // 로그인 후 경로에 로그인되지 않은 상태로 접근 시 로그인 페이지로 리디렉션
@@ -40,5 +41,5 @@ export const middleware = async (request: NextRequest) => {
 
 // matcher 설정: 모든 경로에 대해 middleware가 동작하도록 설정
 export const config = {
-  matcher: ['/login', '/signup', '/mypage', '/epigrams', '/auth/login', '/auth/signup', '/main', '/:path*'],
+  matcher: ['/login', '/signup', '/mypage', '/epigrams', '/auth/login', '/auth/signup', '/main', '/feed', '/:path*'],
 };


### PR DESCRIPTION
이동, 로그인후 랜딩 페이지 접속 불가

## #️⃣ 이슈

- close #131

## 📝 작업 내용
로그인 안된 상태에서 /feed나 /feed의 하위 페이지에 접속 불가
로그인 후 자동으로 main 페이지로 이동
로그인후 렌딩 페이지에 접속 불가
middleware 고치니 회원가입 후 바로 /main으로 이동하게 되었습니다

## 📸 결과물

https://github.com/user-attachments/assets/bd61edf6-3b77-470e-ac47-6d4aa784733b



## 👩‍💻 공유 포인트 및 논의 사항
