### PR TITLE
fix(#139): 2차 검수사항 수정 (메인 헤더/피드 페이지/로그인 페이지)

### DIFF
--- a/src/app/auth/_component/SocialLogins.tsx
+++ b/src/app/auth/_component/SocialLogins.tsx
@@ -5,7 +5,7 @@ export default function SocialLogins({ authType }: { authType: 'LOGIN' | 'SIGNUP
   const actionText = authType === 'LOGIN' ? '로그인하기' : '가입하기';
 
   return (
-    <section className="flex w-full flex-col gap-[24px] text-center">
+    <section className="flex w-full flex-col text-center">
       <div className="pc:mb-[40px] relative mb-[24px] after:absolute after:top-1/2 after:left-0 after:h-[1px] after:w-full after:-translate-y-1/2 after:bg-[#E0E0E0] after:content-['']">
         <h2 className="pc:pr-[25px] pc:pl-[25px] pc:text-pre-xl bg-bg-100 text-pre-xs relative z-1 inline-block pr-[20px] pl-[20px] text-blue-400">
           SNS 계정으로 간편 {actionText}

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -9,7 +9,7 @@ interface AuthLayoutProps {
 export default function AuthLayout({ children }: AuthLayoutProps) {
   return (
     <main className="bg-bg-100 tablet:py-[80px] flex min-h-screen w-full items-center justify-center py-[58px]">
-      <div className="tablet:gap-[80px] box-border flex w-full max-w-[680px] flex-col items-center gap-[50px] px-[20px]">
+      <div className="tablet:gap-[60px] box-border flex w-full max-w-[680px] flex-col items-center gap-[50px] px-[20px]">
         <Link href="/" className="pc:pb-[80px] relative h-[48px] w-[174px] pb-[50px]">
           <Image className="object-contain" src="/assets/images/logo-text.svg" fill alt="로고 이미지" priority />
         </Link>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -56,7 +56,7 @@ export default function LoginPage() {
 
   return (
     <>
-      <div className="mx-auto flex w-full max-w-[312px] flex-col items-center justify-center md:max-w-[384px] lg:max-w-[640px]">
+      <div className="tablet:max-w-none mx-auto flex w-full max-w-[384px] flex-col items-center justify-center">
         <form onSubmit={handleSubmit(onSubmit)} className="flex w-full flex-col gap-[10px]">
           {/* 이메일 입력 */}
           <div className="flex flex-col items-start gap-[8px]">
@@ -85,7 +85,7 @@ export default function LoginPage() {
               <button
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
-                className="absolute top-1/2 right-4 flex -translate-y-1/2 items-center justify-center"
+                className="absolute top-1/2 right-4 flex -translate-y-1/2 cursor-pointer items-center justify-center"
               >
                 <Image
                   src={showPassword ? '/assets/icons/visibility_on.svg' : '/assets/icons/visibility_off.svg'}
@@ -102,7 +102,7 @@ export default function LoginPage() {
           {/* 로그인 버튼 */}
           <button
             type="submit"
-            className={`font-pretendard h-[44px] w-full rounded-[12px] text-[16px] leading-[26px] font-semibold text-white transition ${
+            className={`font-pretendard mt-[10px] h-[44px] w-full rounded-[12px] text-[16px] leading-[26px] font-semibold text-white transition ${
               isValid ? 'cursor-pointer bg-[#454545]' : 'bg-[#CBD3E1] opacity-50'
             }`}
             disabled={!isValid}
@@ -111,12 +111,11 @@ export default function LoginPage() {
           </button>
           {error && <p className="text-sm text-red-500">{error}</p>}
         </form>
-        <div className="h-[10px]" />
-        <p className="font-pretendard flex w-full justify-end gap-2 text-[14px] leading-[24px] font-medium text-[#ABB8CE] md:text-[16px] md:leading-[26px] md:font-normal lg:text-[20px] lg:leading-[32px] lg:font-medium">
+        <p className="pc:text-pre-xl! tablet:text-pre-lg tablet:mb-[60px] text-pre-md mt-[10px] mb-[50px] flex w-full justify-end gap-2 font-medium text-[#ABB8CE]">
           회원이 아니신가요?
           <a
             href="/auth/signup"
-            className="text-[14px] leading-[26px] font-medium text-[#454545] underline md:text-[16px] md:font-semibold lg:text-[20px] lg:leading-[26px] lg:font-medium"
+            className="pc:text-pre-xl! tablet:text-pre-lg text-pre-md font-medium text-[#454545] underline"
           >
             가입하기
           </a>

--- a/src/components/FeedList/index.tsx
+++ b/src/components/FeedList/index.tsx
@@ -8,13 +8,13 @@ import Image from 'next/image';
 import SkeletonFeedCard from '@/components/skeletons/SkeletonFeedCard';
 import EmptyState from '@/components/EmptyState';
 import { getEpigramsList } from '@/lib/Epigram';
-import { useFeedStore } from '@/stores/pageStores';
+import { useMinFeedStore } from '@/stores/pageStores';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
 import { Epigram } from '@/types/Epigram';
 
 export default function FeedList() {
   const pathname = usePathname();
-  const { items: epigrams, hasMore } = useFeedStore();
+  const { items: epigrams, hasMore } = useMinFeedStore();
 
   const { data: session, status } = useSession();
   const token = status === 'authenticated' ? session?.user.accessToken : null;
@@ -27,7 +27,7 @@ export default function FeedList() {
   };
 
   const { loadMore, loading, initialLoading } = usePaginatedList<Epigram>({
-    store: useFeedStore.getState(),
+    store: useMinFeedStore.getState(),
     fetchFn: fetchEpigrams,
   });
 

--- a/src/components/FeedList/index.tsx
+++ b/src/components/FeedList/index.tsx
@@ -8,16 +8,18 @@ import Image from 'next/image';
 import SkeletonFeedCard from '@/components/skeletons/SkeletonFeedCard';
 import EmptyState from '@/components/EmptyState';
 import { getEpigramsList } from '@/lib/Epigram';
-import { useMinFeedStore } from '@/stores/pageStores';
+import { useMainFeedStore, useMyFeedStore } from '@/stores/pageStores';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
 import { Epigram } from '@/types/Epigram';
 
 export default function FeedList() {
   const pathname = usePathname();
-  const { items: epigrams, hasMore } = useMinFeedStore();
-
   const { data: session, status } = useSession();
   const token = status === 'authenticated' ? session?.user.accessToken : null;
+
+  // 경로에 따라 적절한 store 선택
+  const useFeedStore = pathname.startsWith('/mypage') ? useMyFeedStore : useMainFeedStore;
+  const { items: epigrams, hasMore } = useFeedStore();
 
   const fetchEpigrams = async (cursor?: number) => {
     if (!token) return { list: [], totalCount: 0 };
@@ -27,7 +29,7 @@ export default function FeedList() {
   };
 
   const { loadMore, loading, initialLoading } = usePaginatedList<Epigram>({
-    store: useMinFeedStore.getState(),
+    store: useFeedStore.getState(),
     fetchFn: fetchEpigrams,
   });
 

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -27,7 +27,7 @@ export default function MainHeader() {
           <div className="flex items-center gap-[12px]">
             {/* 모바일에서만 보이는 메뉴 아이콘 */}
             <div
-              className="mobile:flex mobile:items-center tablet:hidden h-8 w-auto"
+              className="mobile:flex mobile:items-center tablet:hidden h-8 w-auto cursor-pointer"
               onClick={(e) => {
                 //사이드바 열기
                 e.stopPropagation();
@@ -37,22 +37,24 @@ export default function MainHeader() {
               <Image src="/assets/icons/gnb-menu.svg" alt="Menu Icon" width={24} height={24} className="object-cover" />
             </div>
             {/* 로고 + Epigram 텍스트 */}
-            <div className="flex items-center gap-[4px]">
-              <div className="h-8 w-8">
-                <Image
-                  src="/assets/images/logo.png"
-                  alt="Epigram Logo"
-                  width={36}
-                  height={36}
-                  className="rounded-full object-cover"
-                />
-              </div>
-              <span
-                className="tablet:text-[var(--text-mon-xxs)] tablet:leading-[var(--text-mon-lg--line-height)] pc:text-[var(--text-mon-sm)] pc:leading-[var(--text-mon-lg--line-height)] leading-[var(--text-mon-lg--line-height)] font-black tracking-normal text-[var(--text-mon-xxs)]"
-                style={{ fontFamily: 'var(--font-montserrat)', color: 'var(--color-black-900)', fontWeight: '900' }}
-              >
-                Epigram
-              </span>
+            <div>
+              <Link href="/main" className="flex items-center gap-[4px]">
+                <div className="h-8 w-8">
+                  <Image
+                    src="/assets/images/logo.png"
+                    alt="Epigram Logo"
+                    width={36}
+                    height={36}
+                    className="rounded-full object-cover"
+                  />
+                </div>
+                <span
+                  className="tablet:text-[var(--text-mon-xxs)] tablet:leading-[var(--text-mon-lg--line-height)] pc:text-[var(--text-mon-sm)] pc:leading-[var(--text-mon-lg--line-height)] leading-[var(--text-mon-lg--line-height)] font-black tracking-normal text-[var(--text-mon-xxs)]"
+                  style={{ fontFamily: 'var(--font-montserrat)', color: 'var(--color-black-900)', fontWeight: '900' }}
+                >
+                  Epigram
+                </span>
+              </Link>
             </div>
             {/* 네비게이션 메뉴 (피드, 검색) */}
             <nav
@@ -70,7 +72,7 @@ export default function MainHeader() {
           {/* 유저 프로필 */}
           <div className="relative">
             <div
-              className="flex items-center gap-2"
+              className="flex cursor-pointer items-center gap-2"
               onClick={(e) => {
                 // 드롭다운버튼 열기
                 e.stopPropagation();
@@ -87,7 +89,7 @@ export default function MainHeader() {
               <span className="text-pre-md tablet:inline text-[var(--color-black-500)]">{session?.user.nickname}</span>
             </div>
             {isDropdown && ( //드롭다운
-              <div className="absolute right-0 w-[90px] rounded-md border border-gray-100 bg-white text-center shadow-lg">
+              <div className="absolute right-0 w-[90px] overflow-hidden rounded-md border border-gray-100 bg-white text-center shadow-lg">
                 <div className="text-pre-md font-weight-regular cursor-pointer border-b border-gray-100 p-2 hover:bg-gray-200">
                   <Link href="/mypage" onClick={() => setIsDropdown(false)}>
                     마이 프로필

--- a/src/stores/pageStores.ts
+++ b/src/stores/pageStores.ts
@@ -3,6 +3,7 @@ import { Comment } from '@/types/Comment';
 import { createPaginatedListStore } from './paginatedListStore';
 
 export const useFeedStore = createPaginatedListStore<Epigram>();
-export const useMinFeedStore = createPaginatedListStore<Epigram>();
+export const useMainFeedStore = createPaginatedListStore<Epigram>();
+export const useMyFeedStore = createPaginatedListStore<Epigram>();
 export const useCommentStore = createPaginatedListStore<Comment>();
 export const useMyCommentStore = createPaginatedListStore<Comment>();

--- a/src/stores/pageStores.ts
+++ b/src/stores/pageStores.ts
@@ -3,5 +3,6 @@ import { Comment } from '@/types/Comment';
 import { createPaginatedListStore } from './paginatedListStore';
 
 export const useFeedStore = createPaginatedListStore<Epigram>();
+export const useMinFeedStore = createPaginatedListStore<Epigram>();
 export const useCommentStore = createPaginatedListStore<Comment>();
 export const useMyCommentStore = createPaginatedListStore<Comment>();


### PR DESCRIPTION
## #️⃣ 이슈

- close #139 

## 📝 작업 내용
- 메인 헤더 : 로고 클릭시 메인 페이지로 이동
- 메인 헤더 : 아바타 hover 시 cursor 적용
- 메인 헤더 : 아바타 토글 메뉴 hover 시 border-radius 적용
- 피드 페이지 : 피드 불러오는 store 분리하기
- 로그인 페이지 : 전반적인 css 피그마랑 맞추기 (반응형 포함)
- 로그인 페이지 : 패스워드 보기 버튼에 cursor 적용

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
