### PR TITLE
Fix(#153): 토큰 만료시 자동 재발급

### DIFF
--- a/src/lib/next-auth/auth.ts
+++ b/src/lib/next-auth/auth.ts
@@ -121,7 +121,6 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       }
       const isAccessTokenExpired = Date.now() >= ((token.accessTokenExpires as number) ?? 0);
       if (isAccessTokenExpired) {
-        console.log('🔄 토큰 만료됨, 갱신 시도');
         try {
           const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/refresh-token`, {
             method: 'POST',
@@ -138,7 +137,6 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
           return token;
         }
       }
-      console.log('✅ 저장된 토큰:', token);
       return token;
     },
     async session({ session, token }) {

--- a/src/lib/next-auth/auth.ts
+++ b/src/lib/next-auth/auth.ts
@@ -119,8 +119,9 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
         token.accessToken = user.accessToken;
         token.refreshToken = user.refreshToken;
       }
-      const isAccessTokenExpired = token.accessToken && token.exp && Date.now() >= token.exp * 1000;
+      const isAccessTokenExpired = Date.now() >= ((token.accessTokenExpires as number) ?? 0);
       if (isAccessTokenExpired) {
+        console.log('🔄 토큰 만료됨, 갱신 시도');
         try {
           const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/refresh-token`, {
             method: 'POST',
@@ -134,9 +135,10 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
           token.accessToken = data.accessToken;
         } catch (error) {
           console.error('토큰 갱신 실패:', error);
-          return null;
+          return token;
         }
       }
+      console.log('✅ 저장된 토큰:', token);
       return token;
     },
     async session({ session, token }) {


### PR DESCRIPTION
## #️⃣ Fix

- close #153 

## 📝 작업 내용
- accessToken 만료시 refreshToken을 활용해 재발급 해오는 작업
## 📸 결과물
https://github.com/user-attachments/assets/c5f5c596-8a37-4073-a950-9e7a69b650db
## 👩‍💻 공유 포인트 및 논의 사항
- 제가 우선 accessToken만료 기간을 30분정도로 잡고 체크 했을 땐 accessToken 만료되면 refreshToken을 잘 받아오는걸 확인했습니다. - 백엔드에서 따로 Token 값들의 유효기간이 설정되어 있으니 제가 설정한 유효기간은 지웠고 난중에 확인해봤을 때 제대로 못받아오면 말씀 해주시면 다시 수정해 놓겠습니다.