### PR TITLE
fix:오늘의 감정 block 지정과 감정차트부분 css 수정

### DIFF
--- a/src/app/mypage/_components/MyChart/EmotionPieChart.tsx
+++ b/src/app/mypage/_components/MyChart/EmotionPieChart.tsx
@@ -74,8 +74,8 @@ export default function EmotionPieChart() {
             data={chartData}
             cx="50%"
             cy="50%"
-            innerRadius={40}
-            outerRadius={50}
+            innerRadius="80%"
+            outerRadius="100%"
             fill="#88884d8"
             paddingAngle={5}
             dataKey="value"
@@ -88,7 +88,7 @@ export default function EmotionPieChart() {
       </ResponsiveContainer>
       {topEmotion && (
         <div className="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center">
-          <img src={topEmotion.image} alt={topEmotion.name} className="h-[24px] w-[24px]" />
+          <img src={topEmotion.image} alt={topEmotion.name} className="pc:w-[40px] pc:h-[40px] h-[24px] w-[24px]" />
           <span className="text-pre-lg font-weight-bold">{topEmotion.name}</span>
         </div>
       )}

--- a/src/components/TodayEmotion.tsx
+++ b/src/components/TodayEmotion.tsx
@@ -80,11 +80,9 @@ export default function TodayEmotion({ emotionType }: TodayEmotionProps) {
   const [selectedEmotion, setSelectedEmotion] = useState<EmotionKey | null>(null);
 
   useEffect(() => {
-    if (emotionType === 'main') {
-      const storageEmotion = localStorage.getItem('todayEmotion') as EmotionKey | null;
-      if (storageEmotion && EmotionData[storageEmotion]) {
-        setSelectedEmotion(storageEmotion);
-      }
+    const storageEmotion = localStorage.getItem('todayEmotion') as EmotionKey | null;
+    if (storageEmotion && EmotionData[storageEmotion]) {
+      setSelectedEmotion(storageEmotion);
     }
   }, [emotionType]);
 


### PR DESCRIPTION
## #️⃣ 이슈

- close #161 

## 📝 작업 내용
-마이 페이지 차트부분 반응형으로 만들고 오늘의 감정 부분 메인페이지에서 클릭하여 블록색을 나타내는것을 마이페이지로 넘어왔을 때 똑같이 표시하기로 설정
## 📸 결과물
https://github.com/user-attachments/assets/c7002990-3148-4c41-a17c-25907953fe84
## 👩‍💻 공유 포인트 및 논의 사항
- pc버전일 때 오늘의 감정 차트 부분이 너무 어색하고 크기가 작아서 키우고 오늘의 감정 부분에서 메인페이지에서 클릭하면 그 블록처리한 것이 마이페이지로는 넘어오지 않아서 그부분 수정하였습니다.