### PR TITLE
Feat/167/댓글프로필 모달창 프로필 이미지 연동 / 에피그램 댓글 작성 프로필 이미지 연동

### DIFF
--- a/src/app/feed/[id]/_component/CommentInput.tsx
+++ b/src/app/feed/[id]/_component/CommentInput.tsx
@@ -24,7 +24,7 @@ export default function CommentInput({ userImage, onSubmit }: Props) {
     setIsPrivate(false);
   };
 
-  const fallbackImage = '/assets/icons/comment-user.svg';
+  const fallbackImage = '/assets/images/defaultUser.png';
   const profileImage = userImage?.trim() !== '' ? userImage! : fallbackImage;
 
   return (

--- a/src/components/Comment/CommentItem.tsx
+++ b/src/components/Comment/CommentItem.tsx
@@ -9,7 +9,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import ClientButton from '../Button/ClientButton';
 import ModalLayout from '../Modal/ModalLayout';
-import ModalUSerProfile from '../Modal/ModalUserProfile';
+import ModalUserProfile from '../Modal/ModalUserProfile';
 
 interface Props {
   comment: Comment;
@@ -179,7 +179,7 @@ export function CommentItem({ comment, token, writerId, onDelete, onSave }: Prop
       </CommentCard>
       {isProfileOpen && (
         <ModalLayout type="content" onClose={() => setIsProfileOpen(false)}>
-          <ModalUSerProfile nickname={comment.writer.nickname} />
+          <ModalUserProfile nickname={comment.writer.nickname} image={comment.writer.image} />
         </ModalLayout>
       )}
 

--- a/src/components/Modal/ModalUserProfile.tsx
+++ b/src/components/Modal/ModalUserProfile.tsx
@@ -1,20 +1,17 @@
 'use client';
 
-import Image from 'next/image';
+import { Avatar } from '../Comment/Avatar';
 
-interface ModalUSerProfileProps {
+interface ModalUserProfileProps {
   nickname: string;
-  avatarUrl?: string;
+  image?: string;
 }
 
-export default function ModalUSerProfile({ nickname, avatarUrl }: ModalUSerProfileProps) {
-  const fallbackSrc = '/assets/images/defaultUser.png';
-  const imageSrc = avatarUrl && avatarUrl.trim() !== '' ? avatarUrl : fallbackSrc;
-
+export default function ModalUserProfile({ nickname, image }: ModalUserProfileProps) {
   return (
     <div className="flex flex-col items-center justify-center space-y-3">
       <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-gray-100">
-        <Image src={imageSrc} alt="아바타" width={48} height={48} unoptimized />
+        <Avatar src={image ?? ''} alt="프로필 이미지" className="h-12 w-12" />
       </div>
       <p className="text-pre-md tablet:text-pre-lg pc:text-pre-xl text-black-800 font-semibold">{nickname}</p>
     </div>


### PR DESCRIPTION
## #️⃣ 이슈

- close #167 

## 📝 작업 내용

1. 댓글프로필 모달창 프로필 이미지 연동
2. 에피그램 댓글 작성 프로필 이미지 연동

## 📸 결과물
1. 댓글프로필 모달창 : 프로필 이미지 기본 이미지만 나오던 문제 수정
![모달창](https://github.com/user-attachments/assets/ecbb44eb-9e1d-47f4-b488-58279b23c1f6)

2. 에피그램 댓글 작성 프로필 이미지 : 기존 기본 이미지가 엑박이 뜨던 문제 수정
![댓글쓰기 프로필 아이콘](https://github.com/user-attachments/assets/50b8a66e-d366-4659-996a-ac736435b451)



## 👩‍💻 공유 포인트 및 논의 사항
