### PR TITLE
fix(#169): 댓글 css 스타일 수정

### DIFF
--- a/src/app/feed/[id]/_component/CommentInput.tsx
+++ b/src/app/feed/[id]/_component/CommentInput.tsx
@@ -37,14 +37,14 @@ export default function CommentInput({ userImage, onSubmit }: Props) {
           value={content}
           onChange={(e) => setContent(e.target.value)}
           maxLength={100}
-          className="custom-scrollbar border-line-200 text-pre-sm tablet:text-pre-md pc:text-pre-lg font-regular focus:border-black-600 tablet:h-[80px] pc:h-[104px] h-[66px] w-full resize-none rounded-md border px-3 py-2 outline-none"
+          className="custom-scrollbar border-line-200 text-pre-lg leading-text-pre-lg font-regular text-black-700 pc:text-pre-xl pc:leading-text-pre-xl w-full resize-none rounded-md border px-3 py-2 placeholder-blue-400 outline-none focus:border-blue-600"
         />
 
         <div className="flex items-center justify-between">
           {/* 공개/비공개 토글 */}
           <div className="flex items-center gap-2">
-            <span className="text-pre-xs tablet:text-pre-md pc:text-pre-lg leading-text-iro-xs tablet:leading-text-iro-md pc:leading-text-iro-lg text-black-600 font-semibold">
-              공개
+            <span className="text-pre-xs tablet:text-pre-md pc:text-pre-lg w-12 text-center text-gray-400">
+              {isPrivate ? '비공개' : '공개'}
             </span>
             <button
               onClick={() => setIsPrivate((prev) => !prev)}
@@ -54,7 +54,7 @@ export default function CommentInput({ userImage, onSubmit }: Props) {
             >
               <div
                 className={`h-4 w-4 transform rounded-full bg-blue-100 shadow transition-transform duration-200 ${
-                  isPrivate ? 'translate-x-0' : 'translate-x-5'
+                  isPrivate ? 'translate-x-1' : 'translate-x-5'
                 }`}
               />
             </button>

--- a/src/components/Comment/CommentItem.tsx
+++ b/src/components/Comment/CommentItem.tsx
@@ -122,7 +122,7 @@ export function CommentItem({ comment, token, writerId, onDelete, onSave }: Prop
           {isEditing ? (
             <>
               <textarea
-                className="custom-scrollbar border-line-200 text-pre-lg leading-text-pre-lg font-regular text-black-700 pc:text-pre-xl pc:leading-text-pre-xl focus:border-black-600 w-full resize-none rounded-md border px-3 py-2 outline-none"
+                className="custom-scrollbar border-line-200 text-pre-lg leading-text-pre-lg font-regular text-black-700 pc:text-pre-xl pc:leading-text-pre-xl w-full resize-none rounded-md border px-3 py-2 outline-none focus:border-blue-600"
                 value={editedContent}
                 onChange={(e) => setEditedContent(e.target.value)}
               />
@@ -130,8 +130,8 @@ export function CommentItem({ comment, token, writerId, onDelete, onSave }: Prop
               <div className="flex items-center justify-between">
                 {/* 공개/비공개 토글 */}
                 <div className="flex items-center gap-2">
-                  <span className="text-pre-xs tablet:text-pre-md pc:text-pre-lg leading-text-iro-xs tablet:leading-text-iro-md pc:leading-text-iro-lg text-black-600 font-semibold">
-                    공개
+                  <span className="text-pre-xs tablet:text-pre-md pc:text-pre-lg w-12 text-center text-gray-400">
+                    {isPrivate ? '비공개' : '공개'}
                   </span>
                   <button
                     onClick={() => setIsPrivate(!isPrivate)}
@@ -141,7 +141,7 @@ export function CommentItem({ comment, token, writerId, onDelete, onSave }: Prop
                   >
                     <div
                       className={`h-4 w-4 transform rounded-full bg-blue-100 shadow transition-transform duration-200 ${
-                        isPrivate ? 'translate-x-0' : 'translate-x-5'
+                        isPrivate ? 'translate-x-1' : 'translate-x-5'
                       }`}
                     />
                   </button>


### PR DESCRIPTION
## #️⃣ 이슈

- close #169 

## 📝 작업 내용

스타일 수정사항
1. 댓글 수정모드 : 공개/비공개 토글 스타일 수정
2. 댓글 작성/수정 : 플레이스홀더 색상 변경
3. 댓글 작성/수정 입력란 : 포커스아웃라인 색상 변경 (회원가입/로그인폼과 동일)

## 📸 결과물

https://github.com/user-attachments/assets/d9aea7eb-0cae-4c43-ac32-ffd14b6e4212



## 👩‍💻 공유 포인트 및 논의 사항
