### PR TITLE
 feat(#184) : 마이페이지 프로필 toast 기능 추가

### DIFF
--- a/src/app/mypage/_components/MyUserProfile.tsx
+++ b/src/app/mypage/_components/MyUserProfile.tsx
@@ -116,10 +116,7 @@ export default function MyUserProfile() {
         {editMode ? (
           <>
             <button
-              onClick={() => {
-                notify({ type: 'success', message: '프로필 변경에 성공하였습니다!' });
-                handleSave();
-              }}
+              onClick={handleSave}
               className="text-pre-md font-weight-regular pc:font-weight-medium pc:text-pre-xl pc:h-[48px] pc:w-[100px] bg-line-100 h-[38px] w-[77px] cursor-pointer items-center justify-center rounded-[100px] text-blue-400 hover:bg-gray-200 hover:text-black"
             >
               저장

--- a/src/app/mypage/_components/MyUserProfile.tsx
+++ b/src/app/mypage/_components/MyUserProfile.tsx
@@ -7,6 +7,7 @@ import { useRef, useState } from 'react';
 import { uploadImage } from '@/lib/UploadImage';
 import { patchUserInfo } from '@/lib/patchUserInfo';
 import { useSession } from 'next-auth/react';
+import { notify } from '@/util/toast';
 
 export default function MyUserProfile() {
   const { data: session } = useSession();
@@ -115,13 +116,19 @@ export default function MyUserProfile() {
         {editMode ? (
           <>
             <button
-              onClick={handleSave}
+              onClick={() => {
+                notify({ type: 'success', message: '프로필 변경에 성공하였습니다!' });
+                handleSave();
+              }}
               className="text-pre-md font-weight-regular pc:font-weight-medium pc:text-pre-xl pc:h-[48px] pc:w-[100px] bg-line-100 h-[38px] w-[77px] cursor-pointer items-center justify-center rounded-[100px] text-blue-400 hover:bg-gray-200 hover:text-black"
             >
               저장
             </button>
             <button
-              onClick={handleCancel}
+              onClick={() => {
+                notify({ type: 'info', message: '프로필 변경이 취소되었습니다!' });
+                handleCancel();
+              }}
               className="text-pre-md font-weight-regular pc:font-weight-medium pc:text-pre-xl pc:h-[48px] pc:w-[100px] bg-line-100 h-[38px] w-[77px] cursor-pointer items-center justify-center rounded-[100px] text-blue-400 hover:bg-gray-200 hover:text-black"
             >
               취소

--- a/src/lib/patchUserInfo.ts
+++ b/src/lib/patchUserInfo.ts
@@ -1,3 +1,5 @@
+import { notify } from '@/util/toast';
+
 interface PatchUserInfoArgs {
   nickname?: string;
   image?: string;
@@ -23,10 +25,15 @@ export async function patchUserInfo({ nickname, image, token }: PatchUserInfoArg
   const resText = await response.text();
   console.log('서버 응답:', resText);
 
+  if (response.ok) {
+    notify({ type: 'success', message: '프로필 변경에 성공하였습니다!' });
+  }
+
   if (!response.ok) {
     if (response.status === 400) {
-      alert('이미 사용중인 닉네임 입니다');
+      notify({ type: 'error', message: '중복된 닉네임 입니다!' });
     }
+
     throw new Error('유저 정보 수정 실패');
   }
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #184

## 📝 작업 내용
프로필 변경, 취소, 중복 닉네임시 각자 다른 toast 기능을 추가하였습니다

## 📸 결과물
![image](https://github.com/user-attachments/assets/14dcd5cb-c3b7-4f9f-bc99-4d6a1dd42e4a)
![image](https://github.com/user-attachments/assets/e3849e80-062d-40c6-8935-221549c47e9c)
![image](https://github.com/user-attachments/assets/22753af3-168c-4f36-bf3b-73c85f744404)


## 👩‍💻 공유 포인트 및 논의 사항
