### PR TITLE
Fix(#180):로그인과 회원가입 성공 및 실패 시 toast적용 그리고 메인헤더 z-index적용

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import { signIn, useSession } from 'next-auth/react';
 import SocialLogins from '../_component/SocialLogins';
 import { signinSchema } from '@/lib/validation/auth';
+import { notify } from '@/util/toast';
 
 type LoginFormInputs = z.infer<typeof signinSchema>;
 
@@ -41,9 +42,11 @@ export default function LoginPage() {
 
     if (res?.error) {
       setError('이메일 또는 비밀번호가 다릅니다.'); // NextAuth에서 받은 에러 메시지를 그대로 사용
+      notify({ type: 'error', message: '로그인에 실패했습니다.' });
       return;
     }
 
+    notify({ type: 'success', message: '로그인에 성공하였습니다.' });
     router.push('/');
   };
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -8,6 +8,7 @@ import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { signupSchema, SignupInput } from '@/lib/validation/auth';
+import { notify } from '@/util/toast';
 
 export default function Page() {
   const [isPwVisible, setIsPwVisible] = useState(false);
@@ -43,8 +44,12 @@ export default function Page() {
       if (!response.ok) {
         const errorData = await response.json();
         setError(errorData.error || '회원가입에 실패하셨습니다.');
+        //회원가입 실패
+        notify({ type: 'error', message: '회원가입에 실패했습니다.' });
         return;
       }
+      //회원가입 성공
+      notify({ type: 'success', message: '회원가입에 성공하셨습니다.' });
       // 회원가입 후 바로 로그인 처리
       const signInResponse = await signIn('credentials', {
         redirect: false, // 페이지 이동을 방지

--- a/src/components/Kebab.tsx
+++ b/src/components/Kebab.tsx
@@ -9,7 +9,7 @@ interface KebabProps {
 
 export default function Kebab({ label1, label2, onCLick1, onClick2 }: KebabProps) {
   return (
-    <div className="bg-bg-100 pc:h-[112px] pc:w-[134px] pc:top-[44px] absolute top-[31px] right-0 flex h-[80px] w-[97px] flex-col overflow-hidden rounded-[16px] border border-blue-300">
+    <div className="bg-bg-100 pc:h-[112px] pc:w-[134px] pc:top-[44px] absolute top-[31px] right-0 z-1 flex h-[80px] w-[97px] flex-col overflow-hidden rounded-[16px] border border-blue-300">
       <div
         className="hover:bg-sub-gray-2 text-pre-md font-regular text-black-600 pc:text-pre-xl flex flex-1 cursor-pointer items-center justify-center"
         onClick={() => onCLick1()}


### PR DESCRIPTION
## #️⃣ 이슈

- close #180 

## 📝 작업 내용
- 로그인과 회원가입에서 성공 및 실패 했을 때 거기에 맞는 toast사용
- 메인 헤더에서 프로필 누를시 피드뒤에 케밥이 적용되서 z-index를 줘서 앞에 나오게함.
## 📸 결과물
아주 잘나옵니다.
## 👩‍💻 공유 포인트 및 논의 사항
onSubmit을 설정해놨을 때 onClick이벤트를 설정하지 않아도 type="submit"을 하면 가장 가까운 form 태그의 onsubmit을 실행!
예시로는 로그인과 회원가입 페이지 코드를 보시면 됩니다!
```js
const onSubmit = async (data: LoginFormInputs) => {
    setError(''); // 기존 에러 초기화
    setErrorEmail('');
    setErrorPassword('');

    const res = await signIn('credentials', {
      email: data.email,
      password: data.password,
      redirect: false, // 자동 리다이렉트 방지
    }); // 응답 로그 확인

    if (res?.error) {
      setError('이메일 또는 비밀번호가 다릅니다.'); // NextAuth에서 받은 에러 메시지를 그대로 사용
      notify({ type: 'error', message: '로그인에 실패했습니다.' });
      return;
    }

    notify({ type: 'success', message: '로그인에 성공하였습니다.' });
    router.push('/');
  };

return(
<form onSubmit={handleSubmit(onSubmit)} className="flex w-full flex-col gap-[10px]">
...
<form/>
 <button
            type="submit"
            className={`font-pretendard mt-[10px] h-[44px] w-full rounded-[12px] text-[16px] leading-[26px] font-semibold text-white transition ${
              isValid ? 'cursor-pointer bg-[#454545]' : 'bg-[#CBD3E1] opacity-50'
            }`}
            disabled={!isValid}
          >
            로그인
</button>
)
```