### PR TITLE
Fix(#165): 태그 input 한글 두번 입력 오류 수정

### DIFF
--- a/src/components/Tag/TagsInput.tsx
+++ b/src/components/Tag/TagsInput.tsx
@@ -16,7 +16,7 @@ export function TagsInput({ onAddTag, tags }: TagsInputProps) {
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && inputValue.trim().length > 0 && inputValue.length <= 10) {
+    if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
       const isDuplicate = tags.some((tag) => tag.name === inputValue.trim());
       if (isDuplicate) {
         alert('이 태그는 이미 존재합니다.');

--- a/src/components/Tag/TagsInput.tsx
+++ b/src/components/Tag/TagsInput.tsx
@@ -15,7 +15,7 @@ export function TagsInput({ onAddTag, tags }: TagsInputProps) {
     setInputValue(e.target.value);
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
       const isDuplicate = tags.some((tag) => tag.name === inputValue.trim());
       if (isDuplicate) {
@@ -38,7 +38,7 @@ export function TagsInput({ onAddTag, tags }: TagsInputProps) {
         type="text"
         value={inputValue}
         onChange={handleInputChange}
-        onKeyDown={handleKeyPress}
+        onKeyDown={handleKeyDown}
         className="mobile:px-[16px] mobile:py-[8px] mobile:rounded-[12px] mobile:border-[1px] mobile:border-blue-300 mobile:bg-white mobile:text-text-pre-lg mobile:leading-[26px] mobile:font-normal mobile:tracking-[0%] mobile:mb-[15px] tablet:px-[16px] tablet:py-[8px] tablet:rounded-[12px] tablet:border-[1px] tablet:border-blue-300 tablet:bg-white tablet:text-text-pre-lg tablet:leading-[26px] tablet:font-normal tablet:tracking-[0%] tablet:mb-[16px] pc:px-[16px] pc:py-[8px] pc:rounded-[12px] pc:border-[1px] pc:border-blue-300 pc:bg-white pc:text-text-pre-lg pc:leading-[32px] pc:font-normal pc:tracking-[0%] pc:mb-[22px] focus:outline-2 focus:outline-blue-600"
         placeholder="입력하여 태그 작성 (최대 10자)"
       />

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -25,6 +25,9 @@ export function TagsInput({ onAddTag, tags }: TagsInputProps) {
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
+    e.preventDefault();
+
     if (e.key === 'Enter' && inputValue.trim().length > 0 && inputValue.length <= 10) {
       const isDuplicate = tags.some((tag) => tag.name === inputValue.trim());
       if (isDuplicate) {


### PR DESCRIPTION
## #️⃣ 이슈

- close #165 

## 📝 작업 내용
- 피드 만들기 태그 입력 부분에서 input 한글 두번 입력되는 오류 해결!

## 📸 결과물
![스크린샷 2025-04-08 오후 5 58 03](https://github.com/user-attachments/assets/2eded16c-cdd5-4cad-bcee-f7bfdb0e48ea)

## 👩‍💻 공유 포인트 및 논의 사항
맥북의 크롬에서만 생기는 오류지만 해결했습니다!