### PR TITLE
Fix(#181): 에피그램과 회원가입 리팩토링

### DIFF
--- a/src/app/addepigram/[id]/page.tsx
+++ b/src/app/addepigram/[id]/page.tsx
@@ -15,7 +15,6 @@ export default async function Page({ params }: { params: PageParams }) {
 
   if (!token) return;
   const data = await GetEpigram(Number(id), token);
-  if (!data) return <div>오류가 발생했습니다.</div>;
 
   return <EpigramForm initialValue={data} submitType="수정하기" />;
 }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -63,6 +63,7 @@ export default function Page() {
 
       // 로그인 성공 시 홈으로 이동
       router.push('/');
+      notify({ type: 'success', message: '회원가입 되었습니다.' });
     } catch (error) {
       console.error(error);
     }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -9,10 +9,12 @@ import { useRouter } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { signupSchema, SignupInput } from '@/lib/validation/auth';
 import { notify } from '@/util/toast';
+import Spinner from '@/components/Spinner';
 
 export default function Page() {
   const [isPwVisible, setIsPwVisible] = useState(false);
   const [isPwConfirmVisible, setIsPwConfirmVisible] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const router = useRouter();
   const {
@@ -31,6 +33,7 @@ export default function Page() {
   });
 
   const SubmitForm = async (data: SignupInput) => {
+    setIsLoading(true);
     setError('');
     try {
       const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signUp`, {
@@ -48,8 +51,6 @@ export default function Page() {
         notify({ type: 'error', message: '회원가입에 실패했습니다.' });
         return;
       }
-      //회원가입 성공
-      notify({ type: 'success', message: '회원가입에 성공하셨습니다.' });
       // 회원가입 후 바로 로그인 처리
       const signInResponse = await signIn('credentials', {
         redirect: false, // 페이지 이동을 방지
@@ -66,6 +67,8 @@ export default function Page() {
       notify({ type: 'success', message: '회원가입 되었습니다.' });
     } catch (error) {
       console.error(error);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -168,19 +171,26 @@ export default function Page() {
           </div>
         </div>
         <button
-          className={`text-pre-lg pc:text-pre-xl pc:py-[16px] rounded-[12px] px-[16px] py-[9px] font-semibold text-blue-100 ${isValid ? `bg-black-500 cursor-pointer` : `bg-blue-300`}`}
+          className={`text-pre-lg pc:text-pre-xl pc:py-[16px] relative rounded-[12px] px-[16px] py-[9px] font-semibold text-blue-100 ${isValid ? `bg-black-500 cursor-pointer` : `bg-blue-300`}`}
           type="submit"
           disabled={!isValid}
         >
           가입하기
+          {error && (
+            <p className="text-state-error text-pre-xs font-regular tablet:text-pre-md pc:text-pre-lg absolute top-[50px] left-[0px]">
+              {error}
+            </p>
+          )}
         </button>
-        {error && (
-          <p className="text-state-error text-pre-xs font-regular tablet:text-pre-md pc:text-pre-lg tablet:bottom-[-26px] pc:bottom-[-28px] bottom-[-22px]">
-            {error}
-          </p>
-        )}
       </form>
       <SocialLogins authType={'SIGNUP'} />
+      {isLoading && (
+        <div className="bg-black-600/20 fixed inset-0 z-2 flex items-center justify-center">
+          <div className="bg-bg-100 pc:h-[100px] pc:w-[100px] flex h-[80px] w-[80px] items-center justify-center rounded-[16px]">
+            <Spinner size={60} className="pc:h-[56px] pc:w-[90px] h-[30px]" />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/main/_conponents/LatestEpigrams.tsx
+++ b/src/app/main/_conponents/LatestEpigrams.tsx
@@ -3,7 +3,7 @@ import FeedList from '@/components/FeedList';
 export default function LatestEpigrams() {
   return (
     <>
-      <h2 className="pc:mb-[40px] text-pre-lg font-weight-semibold txt-color-black-900 pc:text-iro-2xl mb-[24px]">
+      <h2 className="pc:mb-[40px] text-pre-lg txt-color-black-900 pc:text-iro-2xl mb-[24px] font-semibold">
         최신 에피그램
       </h2>
       <FeedList />

--- a/src/app/main/_conponents/todayEpigrams.tsx
+++ b/src/app/main/_conponents/todayEpigrams.tsx
@@ -25,7 +25,7 @@ export default function TodayEpirams() {
 
   return (
     <section className="pc:gap-[40px] pc:mt-[120px] mt-[24px] grid h-full w-full gap-[24px]">
-      <h2 className="text-pre-lg font-weight-semibold txt-color-black-900 pc:text-iro-2xl">오늘의 에피그램</h2>
+      <h2 className="text-pre-lg txt-color-black-900 pc:text-iro-2xl font-semibold">오늘의 에피그램</h2>
       <div className="bg-color-blue-100 h-full w-full rounded-[16px]">
         <FeedCard data={todayEpigram} />
       </div>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
             <TodayEpirams />
           </div>
           <div className="pc:gap-[40px] pc:mb-[140px] mb-[56px] grid gap-[24px]">
-            <div className="text-pre-lg pc:text-iro-2xl">오늘의 감정은 어떤가요?</div>
+            <div className="text-pre-lg pc:text-iro-2xl font-semibold">오늘의 감정은 어떤가요?</div>
             <TodayEmotion emotionType="main" />
           </div>
           <div className="pc:mb-[140px] mb-[56px]">

--- a/src/app/mypage/_components/MyCalender/EmotionFilter.tsx
+++ b/src/app/mypage/_components/MyCalender/EmotionFilter.tsx
@@ -6,11 +6,12 @@ export const EmotionData = {
   MOVED: {
     image: '/assets/icons/heart_face.svg',
     name: '감동',
+    hover: 'border-yellow',
   },
-  HAPPY: { image: '/assets/icons/smiling_face.svg', name: '기쁨' },
-  WORRIED: { image: '/assets/icons/thinking_face.svg', name: '고민' },
-  SAD: { image: '/assets/icons/sad_face.svg', name: '슬픔' },
-  ANGRY: { image: '/assets/icons/angry_face.svg', name: '분노' },
+  HAPPY: { image: '/assets/icons/smiling_face.svg', name: '기쁨', hover: 'border-green' },
+  WORRIED: { image: '/assets/icons/thinking_face.svg', name: '고민', hover: 'border-purple' },
+  SAD: { image: '/assets/icons/sad_face.svg', name: '슬픔', hover: 'border-blue' },
+  ANGRY: { image: '/assets/icons/angry_face.svg', name: '분노', hover: 'border-red' },
 };
 
 export type EmotionKey = keyof typeof EmotionData;
@@ -40,7 +41,7 @@ function Emotion({
         </div>
         {isSelected && (
           <div
-            className={`border-yellow pc:border-[4px] absolute top-0 right-0 bottom-0 left-0 rounded-[8px] border-[3px]`}
+            className={`${EmotionData[emotion].hover} pc:border-[4px] absolute top-0 right-0 bottom-0 left-0 rounded-[8px] border-[3px]`}
           ></div>
         )}
       </div>

--- a/src/app/mypage/_components/MyCalender/MyCalender.tsx
+++ b/src/app/mypage/_components/MyCalender/MyCalender.tsx
@@ -34,7 +34,7 @@ export default function MyCalender({ writerId }: { writerId: string }) {
         <span className="text-pre-lg text-black-600 pc:text-pre-2xl font-semibold">
           {moment(displayMonth).format('YYYY년 M월')}
         </span>
-        <div className="flex h-[548px] w-[637px] items-center justify-center">
+        <div className="pc:h-[548px] tablet:h-[326px] flex h-[264px] items-center justify-center">
           <Spinner size={60} className="h-[56px] w-[90px]" />
         </div>
       </div>

--- a/src/app/mypage/_components/MyCalender/MyCalender.tsx
+++ b/src/app/mypage/_components/MyCalender/MyCalender.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { GetMonthEmotion } from '@/lib/Emotionlog';
 import moment from 'moment';
 import { useEmotionContext } from '../EmotionContext';
+import Spinner from '@/components/Spinner';
 
 export default function MyCalender({ writerId }: { writerId: string }) {
   const [data, setData] = useState<EmotionLog[]>();
@@ -27,7 +28,17 @@ export default function MyCalender({ writerId }: { writerId: string }) {
     getData();
   }, [displayMonth, todayEmotion]);
 
-  if (!data) return;
+  if (!data)
+    return (
+      <div className="flex flex-col">
+        <span className="text-pre-lg text-black-600 pc:text-pre-2xl font-semibold">
+          {moment(displayMonth).format('YYYY년 M월')}
+        </span>
+        <div className="flex h-[548px] w-[637px] items-center justify-center">
+          <Spinner size={60} className="h-[56px] w-[90px]" />
+        </div>
+      </div>
+    );
 
   return <CustomCalender data={data} displayMonth={displayMonth} setDisplayMonth={setDisplayMonth} />;
 }

--- a/src/app/mypage/_components/TodayEmotionHeader.tsx
+++ b/src/app/mypage/_components/TodayEmotionHeader.tsx
@@ -5,8 +5,8 @@ export default function TodayEmotionHeader() {
   return (
     <div className="flex w-full flex-col items-center justify-center gap-[22px]">
       <div className="flex w-full items-center justify-between">
-        <p className="text-pre-lg font-weight-semibold pc:text-pre-2xl">오늘의 감정</p>
-        <p className="text-pre-lg font-weight-regular pc:text-mon-sm text-blue-400">{formattedDate}</p>
+        <p className="text-pre-lg pc:text-pre-2xl font-semibold">오늘의 감정</p>
+        <p className="text-pre-lg font-regular pc:text-mon-sm text-blue-400">{formattedDate}</p>
       </div>
     </div>
   );

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -20,16 +20,18 @@ export default async function MyPage() {
           <MyUserProfile />
         </div>
         <EmotionProvider>
-          <div className="pc:pb-[165px] tablet:pb-[62px] pc:gap-[48px] m-auto flex h-full w-full max-w-[680px] flex-col justify-center gap-[16px] px-[24px] pt-[58px] pb-[58px]">
-            <TodayEmotionHeader />
-            <TodayEmotion emotionType="mypage" />
-          </div>
-          <div className="pc:pb-[82px] tablet:pb-[56px] pc:gap-[48px] m-auto flex h-full w-full max-w-[680px] flex-col justify-center gap-[16px] px-[24px] pt-[58px] pb-[40px]">
+          <div className="pc:pb-[82px] tablet:pb-[56px] pc:gap-[164px] tablet:gap-[60px] m-auto flex h-full w-full max-w-[680px] flex-col justify-center gap-[56px] px-[24px] pb-[40px]">
+            <div className="pc:gap-[48px] flex flex-col gap-[24px]">
+              <TodayEmotionHeader />
+              <TodayEmotion emotionType="mypage" />
+            </div>
             <MyCalender writerId={writerId} />
-            <h1 className="pc:text-pre-2xl text-pre-lg font-weight-semibold">감정 차트</h1>
-            <div className="border-line-100 pc:h-[264px] tablet:h-[230px] flex h-full w-full items-center justify-between rounded-lg border p-[30px]">
-              <EmotionPieChart />
-              <EmotionRankList />
+            <div className="pc:gap-[48px] flex flex-col gap-[16px]">
+              <h1 className="pc:text-pre-2xl text-pre-lg font-semibold">감정 차트</h1>
+              <div className="border-line-100 pc:h-[264px] tablet:h-[230px] flex h-full w-full items-center justify-between rounded-lg border p-[30px]">
+                <EmotionPieChart />
+                <EmotionRankList />
+              </div>
             </div>
           </div>
         </EmotionProvider>

--- a/src/components/EpigramForm.tsx
+++ b/src/components/EpigramForm.tsx
@@ -6,8 +6,9 @@ import { AddEpigram } from '@/types/Epigram';
 import { notify } from '@/util/toast';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { ChangeEvent, useEffect } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import Spinner from './Spinner';
 
 interface EpigramData extends AddEpigram {
   id: number;
@@ -37,6 +38,7 @@ export default function EpigramForm({
       authorSelected: initialValue?.authorSelected || '직접 입력',
     },
   });
+  const [isLoading, setIsloading] = useState(false);
 
   const { data: session, status } = useSession();
   const router = useRouter();
@@ -63,6 +65,7 @@ export default function EpigramForm({
 
   const submitEpigram = async (type: 'post' | 'patch') => {
     if (!initialValue?.id || !token) return;
+    setIsloading(true);
     const allValues = watch();
     return type === 'patch'
       ? await PatchEpigram(allValues, initialValue.id, token)
@@ -72,6 +75,7 @@ export default function EpigramForm({
   const handleSubmitForm = async (type: 'post' | 'patch') => {
     const response = await submitEpigram(type);
     if (!response) return;
+    setIsloading(false);
 
     notify({ type: 'success', message: type === 'patch' ? '게시물이 수정되었습니다.' : '게시물이 작성되었습니다.' });
     router.push(`/feed/${response.id}`);
@@ -235,6 +239,13 @@ export default function EpigramForm({
           {submitType === '작성하기' ? '작성 완료' : '수정 완료'}
         </button>
       </form>
+      {isLoading && (
+        <div className="bg-black-600/20 fixed inset-0 z-2 flex items-center justify-center">
+          <div className="bg-bg-100 flex h-[100px] w-[100px] items-center justify-center rounded-[16px]">
+            <Spinner size={60} className="h-[56px] w-[90px]" />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/EpigramForm.tsx
+++ b/src/components/EpigramForm.tsx
@@ -186,19 +186,12 @@ export default function EpigramForm({
             </div>
           </div>
           <div className="pc:gap-[16px] flex flex-col gap-[8px]">
-            <div className="flex gap-[4px]">
-              <label
-                htmlFor="referenceTitle"
-                className="text-pre-md text-black-600 tablet:text-pre-lg pc:text-pre-xl font-semibold"
-              >
-                출처
-              </label>
-              <div className="relative">
-                <span className="text-pre-lg text-state-error tablet:text-pre-lg pc:text-pre-xl pc:top-[2px] absolute top-[1px] font-medium">
-                  *
-                </span>
-              </div>
-            </div>
+            <label
+              htmlFor="referenceTitle"
+              className="text-pre-md text-black-600 tablet:text-pre-lg pc:text-pre-xl font-semibold"
+            >
+              출처
+            </label>
             <input
               id="referenceTitle"
               className="text-pre-lg font-regular text-black-950 pc:text-pre-xl pc:h-[64px] h-[44px] rounded-[12px] border border-blue-300 px-[16px] placeholder:text-blue-400 focus:outline-blue-600"

--- a/src/components/EpigramForm.tsx
+++ b/src/components/EpigramForm.tsx
@@ -241,8 +241,8 @@ export default function EpigramForm({
       </form>
       {isLoading && (
         <div className="bg-black-600/20 fixed inset-0 z-2 flex items-center justify-center">
-          <div className="bg-bg-100 flex h-[100px] w-[100px] items-center justify-center rounded-[16px]">
-            <Spinner size={60} className="h-[56px] w-[90px]" />
+          <div className="bg-bg-100 pc:h-[100px] pc:w-[100px] flex h-[80px] w-[80px] items-center justify-center rounded-[16px]">
+            <Spinner size={60} className="pc:h-[56px] pc:w-[90px] h-[30px]" />
           </div>
         </div>
       )}

--- a/src/components/PageBackground.tsx
+++ b/src/components/PageBackground.tsx
@@ -15,7 +15,6 @@ const backgroundColors: Record<string, string> = {
 
 export default function PageBackground({ children }: { children: ReactNode }) {
   const pathname = usePathname();
-  // const bgColor = backgroundColors[pathname] || 'bg-bg-100';
   const bgColor = backgroundColors[pathname] || (pathname.startsWith('/addepigram/') ? 'bg-white' : 'bg-bg-100');
 
   return <div className={`${bgColor} min-h-screen`}>{children}</div>;

--- a/src/components/TodayEmotion.tsx
+++ b/src/components/TodayEmotion.tsx
@@ -5,27 +5,33 @@ import Image from 'next/image';
 import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useEmotionContext } from '@/app/mypage/_components/EmotionContext';
+import { notify } from '@/util/toast';
 
 const EmotionData = {
   감동: {
     image: '/assets/icons/heart_face.svg',
     name: 'MOVED',
+    hover: 'border-yellow',
   },
   기쁨: {
     image: '/assets/icons/smiling_face.svg',
     name: 'HAPPY',
+    hover: 'border-green',
   },
   고민: {
     image: '/assets/icons/thinking_face.svg',
     name: 'WORRIED',
+    hover: 'border-purple',
   },
   슬픔: {
     image: '/assets/icons/sad_face.svg',
     name: 'SAD',
+    hover: 'border-blue',
   },
   분노: {
     image: '/assets/icons/angry_face.svg',
     name: 'ANGRY',
+    hover: 'border-red',
   },
 };
 
@@ -40,10 +46,9 @@ interface EmotionProps {
   isSelected: boolean;
   isDisabled: boolean;
   onClick: () => void;
-  emotionType: string;
 }
 
-function Emotion({ emotion, isSelected, isDisabled, onClick, emotionType }: EmotionProps) {
+function Emotion({ emotion, isSelected, isDisabled, onClick }: EmotionProps) {
   return (
     <div
       className={`flex cursor-pointer flex-col items-center gap-[8px] ${isDisabled ? 'cursor-not-allowed opacity-50' : ''}`}
@@ -63,7 +68,7 @@ function Emotion({ emotion, isSelected, isDisabled, onClick, emotionType }: Emot
         </div>
         {isSelected && (
           <div
-            className={`${emotionType === 'main' ? 'border-yellow' : 'border-green'} pc:border-[4px] absolute top-0 right-0 bottom-0 left-0 rounded-[16px] border-[3px]`}
+            className={`${EmotionData[emotion].hover} pc:border-[4px] absolute top-0 right-0 bottom-0 left-0 rounded-[16px] border-[3px]`}
           ></div>
         )}
       </div>
@@ -90,7 +95,7 @@ export default function TodayEmotion({ emotionType }: TodayEmotionProps) {
 
   const OnClickEmotion = async (emotion: EmotionKey) => {
     if (!session?.user.accessToken) {
-      console.error('Access token is undefined');
+      notify({ type: 'error', message: '토큰이 유효하지 않습니다.' });
       return;
     }
 
@@ -99,7 +104,6 @@ export default function TodayEmotion({ emotionType }: TodayEmotionProps) {
     const response = await PostTodayEmotion(EmotionData[emotion].name, session.user.accessToken);
     if (!response) return;
 
-    console.log(`오늘의 감정 등록 완료: ${emotion}`);
     setSelectedEmotion(emotion);
 
     if (emotionType) {
@@ -114,7 +118,6 @@ export default function TodayEmotion({ emotionType }: TodayEmotionProps) {
         <Emotion
           key={emotion}
           emotion={emotion as EmotionKey}
-          emotionType={emotionType}
           isSelected={selectedEmotion === emotion}
           isDisabled={emotionType === 'main' ? !!selectedEmotion : false}
           onClick={() => OnClickEmotion(emotion as EmotionKey)}

--- a/src/lib/Epigram.ts
+++ b/src/lib/Epigram.ts
@@ -1,5 +1,4 @@
-import { Epigram } from '@/types/Epigram';
-import { AddEpigram } from '@/components/EpigramForm';
+import { AddEpigram, Epigram } from '@/types/Epigram';
 // @ts-expect-error : 타입스크립트가 notFound를 오류로 인식합니다. 작동은 잘 됩니다.
 import { notFound } from 'next/navigation';
 import { CommentList } from '@/types/Comment';

--- a/src/types/Epigram.ts
+++ b/src/types/Epigram.ts
@@ -60,3 +60,12 @@ export interface EpigramCommentList {
   nextCursor: number;
   list: EpigramComment[];
 }
+
+export interface AddEpigram {
+  tags: EpigramTag[];
+  referenceUrl: string;
+  referenceTitle: string;
+  author: string;
+  content: string;
+  authorSelected: string;
+}


### PR DESCRIPTION
## #️⃣ 이슈

- close #181 

## 📝 작업 내용

**에피그램 작성/수정**
- 에피그램 제출 폼 함수 관심사정리
- 에피그램 폼 제출 시 로딩 적용

**마이페이지**
- 마이페이지 캘린더 로딩 적용
- 오늘의 감정 색상 변경 => 기존에는 메인페이지와 마이페이지에서의 감정을 클릭시 focus되는 테두리 색상이 다른줄 알았는데, 감정마다 테두리 색상이 다른것으로 확인하여 고쳤습니다.

**회원가입**
- 회원가입하고 폼 제출시 로딩 적용


메인 페이지와 마이페이지의 title 글자들에 semibold가 적용이 안되어있는것 같아서 따로 수정했습니다.
마이페이지의 각 컴포넌트들의 간격이 이상한 것 같아서 감싸고 있는 레이아웃용 div태그도 조금 수정했습니다.

## 📸 결과물

오늘의 감정

https://github.com/user-attachments/assets/79d37d75-56ec-4cfe-a952-117f917f89d4



폼 제출시 아래처럼 로딩이 되도록 해뒀습니다.
![image](https://github.com/user-attachments/assets/70cf0efe-d01e-403b-b79c-b2f32a697abe)


## 👩‍💻 공유 포인트 및 논의 사항
