### PR TITLE
Fix/199/상세페이지 댓글작성 프로필 이미지 실시간 연동

### DIFF
--- a/src/app/feed/[id]/_component/CommentInput.tsx
+++ b/src/app/feed/[id]/_component/CommentInput.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Avatar } from '@/components/Comment/Avatar';
 import ClientButton from '@/components/Button/ClientButton';
-import { useSession } from 'next-auth/react';
-import { createComment } from '@/lib/Comment';
 
 interface Props {
   onSubmit: (content: string, isPrivate: boolean) => void;

--- a/src/app/feed/[id]/_component/CommentInput.tsx
+++ b/src/app/feed/[id]/_component/CommentInput.tsx
@@ -1,27 +1,35 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Avatar } from '@/components/Comment/Avatar';
 import ClientButton from '@/components/Button/ClientButton';
+import { useSession } from 'next-auth/react';
+import { createComment } from '@/lib/Comment';
 
 interface Props {
-  userImage?: string;
   onSubmit: (content: string, isPrivate: boolean) => void;
+  userImage: string | null;
 }
 
-export default function CommentInput({ userImage, onSubmit }: Props) {
+export default function CommentInput({ onSubmit, userImage }: Props) {
   const [content, setContent] = useState('');
   const [isPrivate, setIsPrivate] = useState(false);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (content.trim() === '') {
       alert('댓글 내용을 입력해주세요.');
       return;
     }
 
-    onSubmit(content, isPrivate);
-    setContent('');
-    setIsPrivate(false);
+    try {
+      // 댓글 작성 API 호출
+      onSubmit(content, isPrivate);
+      setContent('');
+      setIsPrivate(false);
+    } catch (error) {
+      console.error('댓글 작성 실패:', error);
+      alert('댓글 작성 중 오류가 발생했습니다.');
+    }
   };
 
   return (

--- a/src/app/mypage/_components/MyCommentList.tsx
+++ b/src/app/mypage/_components/MyCommentList.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CommentItem } from '@/components/Comment/CommentItem';
-import { getUserComments } from '@/lib/User';
+import { fetchUserProfile, getUserComments } from '@/lib/User';
 import { useSession } from 'next-auth/react';
 import { useMyCommentStore } from '@/stores/pageStores';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
@@ -28,11 +28,25 @@ export default function MyCommentList() {
     fetchFn: fetchMyComments,
   });
 
-  useEffect(() => {
-    if (status === 'authenticated' && token && userId && comments.length === 0) {
-      loadMore();
+  const [userImage, setUserImage] = useState<string | null>(null);
+  const [userNickname, setUserNickname] = useState<string | null>(null);
+
+  const updateUserProfile = async () => {
+    if (!token) return;
+    try {
+      const data = await fetchUserProfile(token);
+      setUserImage(data?.image || '');
+      setUserNickname(data?.nickname || '');
+    } catch (error) {
+      console.error('프로필 정보를 불러오는 데 실패했습니다.', error);
     }
-  }, [status, token, userId, comments.length]);
+  };
+
+  useEffect(() => {
+    if (status === 'authenticated' && token && userId) {
+      updateUserProfile();
+    }
+  }, [status, token, userId]);
 
   if (status === 'loading') return <div>로딩 중...</div>;
   if (!session) return <div>로그인이 필요합니다.</div>;
@@ -55,6 +69,8 @@ export default function MyCommentList() {
           key={comment.id}
           comment={comment}
           token={token!}
+          userImage={userImage}
+          userNickname={userNickname}
           onDelete={(id) => useMyCommentStore.getState().setState({ items: comments.filter((c) => c.id !== id) })}
           onSave={(updated) =>
             useMyCommentStore.getState().setState({ items: comments.map((c) => (c.id === updated.id ? updated : c)) })

--- a/src/app/mypage/_components/MyUserProfile.tsx
+++ b/src/app/mypage/_components/MyUserProfile.tsx
@@ -8,10 +8,9 @@ import { uploadImage } from '@/lib/UploadImage';
 import { patchUserInfo } from '@/lib/patchUserInfo';
 import { notify } from '@/util/toast';
 
-
 export default function MyUserProfile() {
   const { isLoading, user, refetchUser } = useFetchUser();
-  const { data: session } = useSession();
+  const { data: session, update } = useSession();
   const token = session?.user.accessToken;
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -59,6 +58,9 @@ export default function MyUserProfile() {
 
       // 저장 후 새로 서버에서 유저 정보 가져오기
       await refetchUser();
+
+      // 세션도 수동으로 새로고침
+      await update(); // 세션 갱신
 
       setEditMode(false);
       setPreviewImage(null);

--- a/src/components/Comment/CommentItem.tsx
+++ b/src/components/Comment/CommentItem.tsx
@@ -19,9 +19,11 @@ interface Props {
   onDelete: (id: number) => void;
   onSave: (updated: Comment) => void;
   onClick?: () => void;
+  userImage?: string | null;
+  userNickname?: string | null;
 }
 
-export function CommentItem({ comment, token, writerId, onDelete, onSave, onClick }: Props) {
+export function CommentItem({ comment, token, writerId, onDelete, onSave, onClick, userImage, userNickname }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState(comment.content);
   const [isPrivate, setIsPrivate] = useState(comment.isPrivate);
@@ -93,8 +95,8 @@ export function CommentItem({ comment, token, writerId, onDelete, onSave, onClic
           }}
         >
           <Avatar
-            src={comment.writer.image}
-            alt={comment.writer.nickname}
+            src={userImage ?? comment.writer.image}
+            alt={'프로필 이미지'}
             className="mr-4 h-12 w-12 cursor-pointer rounded-full transition-transform duration-200 hover:scale-105 hover:shadow-md"
           />
         </button>
@@ -108,7 +110,7 @@ export function CommentItem({ comment, token, writerId, onDelete, onSave, onClic
                 }}
                 className="text-pre-xs tablet:text-pre-lg pc:text-pre-lg font-regular text-black-300 cursor-pointer hover:underline"
               >
-                {comment.writer.nickname}
+                {userNickname ?? comment.writer.nickname}
               </button>
               <span className="text-pre-xs tablet:text-pre-lg pc:text-pre-lg font-regular text-black-300">
                 {formatTime(comment.createdAt)}
@@ -208,7 +210,10 @@ export function CommentItem({ comment, token, writerId, onDelete, onSave, onClic
       </CommentCard>
       {isProfileOpen && (
         <ModalLayout type="content" onClose={() => setIsProfileOpen(false)}>
-          <ModalUserProfile nickname={comment.writer.nickname} image={comment.writer.image} />
+          <ModalUserProfile
+            nickname={userNickname ?? comment.writer.nickname}
+            image={userImage ?? comment.writer.image}
+          />
         </ModalLayout>
       )}
 

--- a/src/lib/User.ts
+++ b/src/lib/User.ts
@@ -34,6 +34,27 @@ export interface UserCommentList {
   list: UserComment[];
 }
 
+// 사용자 정보 조회 api
+export const fetchUserProfile = async (token: string) => {
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/me`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('사용자 정보를 가져오는 데 실패했습니다.');
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error('API 요청 실패:', error);
+    throw error;
+  }
+};
+
 export async function GetUserInfo(id: number) {
   try {
     const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/${id}`, {


### PR DESCRIPTION
## #️⃣ 이슈

- close #199 

## 📝 작업 내용

1. 마이페이지에서 프로필 수정후(이미지, 닉네임) 댓글 아이템이 나오는 부분 실시간으로 프로필 이미지 / 닉네임 업데이트

## 📸 결과물

https://github.com/user-attachments/assets/2547fc20-c726-4c90-9548-3496e710e1b1




## 👩‍💻 공유 포인트 및 논의 사항
